### PR TITLE
feat(openaicompat): reasoning_content + provider quirks for Kimi K2.5 & GLM 5.0

### DIFF
--- a/docs/plans/2026-03-23-openaicompat-reasoning-test-plan.md
+++ b/docs/plans/2026-03-23-openaicompat-reasoning-test-plan.md
@@ -1,0 +1,423 @@
+# Test Plan: OpenAI-Compatible Adapter Reasoning Content & Provider Quirk Support
+
+## Sources of Truth
+
+1. **Kimi K2.5 / GLM 5.0 API documentation** -- defines the `reasoning_content` field shape, locked hyperparameters, `tool_choice` restrictions, non-standard finish reasons, empty content rejection, and stop sequence limits.
+2. **Unified LLM spec** (`unified-llm-spec.md`) -- defines `ContentThinking`, `ThinkingData`, `StreamEventReasoningStart/Delta/End`, `Usage.ReasoningTokens`, `FinishReason` with `.Reason` and `.Raw`.
+3. **`llm/types.go`** -- concrete Go types for the unified spec: `ContentPart`, `ThinkingData`, `StreamEvent`, `FinishReason`, `Usage`, `NormalizeFinishReason`.
+4. **Existing Anthropic and Google adapters** -- working reference implementations for thinking content parsing, reasoning token estimation (chars/4 heuristic), and reasoning stream events.
+5. **Existing `openaicompat` test suite** -- 24 tests in `adapter_test.go`, all passing. These form the regression baseline and must pass unchanged throughout.
+
+## Harness
+
+All tests use the existing `httptest.NewServer` pattern already established in `llm/providers/openaicompat/adapter_test.go`. Mock HTTP servers return hand-crafted JSON payloads matching real Kimi K2.5 and GLM 5.0 response shapes. This is deterministic, fast, and requires no API keys. No new harness infrastructure is needed.
+
+The test file is `llm/providers/openaicompat/adapter_test.go`. All new tests land there alongside the existing 24 tests.
+
+---
+
+## Test Plan
+
+### 1. Non-streaming: reasoning_content parsed as ContentThinking
+
+- **Name**: Non-streaming response with reasoning_content produces ContentThinking part before ContentText part
+- **Type**: scenario
+- **Disposition**: new
+- **Harness**: httptest mock returning `{"reasoning_content": "...", "content": "..."}` in `choices[0].message`
+- **Preconditions**: Adapter with no quirks configured. Mock server returns a response with both `reasoning_content` and `content` fields populated.
+- **Actions**: Call `a.Complete()` with a simple user message.
+- **Expected outcome**:
+  - `resp.Message.Content` has at least 2 parts.
+  - First part: `Kind == ContentThinking`, `Thinking.Text` matches the reasoning_content string exactly.
+  - Second part: `Kind == ContentText`, `Text` matches the content string exactly.
+  - `resp.ReasoningText()` returns the reasoning_content string.
+  - Source: Kimi K2.5 API docs (reasoning_content field), unified spec (ContentThinking kind), `llm/types.go:362` (`ReasoningText()`).
+- **Interactions**: Tests the `fromChatCompletionResponse` parsing path. Incidentally verifies `chatMessage` struct deserialization.
+
+### 2. Non-streaming: response without reasoning_content is unchanged
+
+- **Name**: Non-streaming response without reasoning_content produces only ContentText (no spurious thinking)
+- **Type**: regression
+- **Disposition**: new
+- **Harness**: httptest mock returning standard `{"content": "..."}` response (no reasoning_content field)
+- **Preconditions**: Adapter with no quirks. Mock server returns a standard response.
+- **Actions**: Call `a.Complete()` with a simple user message.
+- **Expected outcome**:
+  - `resp.Message.Content` has exactly 1 part with `Kind == ContentText`.
+  - `resp.ReasoningText()` returns empty string.
+  - Source: unified spec -- `ContentThinking` should not appear when no reasoning occurred.
+- **Interactions**: Guards against regressions in the existing text-only parsing path.
+
+### 3. Streaming: reasoning_content deltas emit REASONING_START/DELTA/END then TEXT_START/DELTA/END
+
+- **Name**: Streaming reasoning_content deltas followed by content deltas produce correct event ordering
+- **Type**: scenario
+- **Disposition**: new
+- **Harness**: httptest SSE mock sending reasoning_content delta chunks then content delta chunks then `[DONE]`
+- **Preconditions**: Adapter with no quirks. Mock SSE server sends: 2 reasoning_content deltas, then 2 content deltas, then finish_reason stop, then `[DONE]`.
+- **Actions**: Call `a.Stream()`, drain all events from `st.Events()`.
+- **Expected outcome**:
+  - Collected reasoning delta text (joined) equals the full reasoning string.
+  - Collected text delta text (joined) equals the full content string.
+  - Event ordering: `REASONING_START` appears before any `REASONING_DELTA`; `REASONING_END` appears after last `REASONING_DELTA` and before `TEXT_START`; `TEXT_START` appears before `TEXT_DELTA`; `TEXT_END` appears before `FINISH`.
+  - Source: Kimi K2.5 streaming docs (reasoning_content in deltas), unified spec (REASONING_START/DELTA/END event types and ordering).
+- **Interactions**: Tests the SSE parsing goroutine's reasoning state machine. Interacts with the `llm.ChanStream` event channel.
+
+### 4. Streaming: reasoning_content in final FINISH response
+
+- **Name**: Final FINISH event's Response contains ContentThinking from streamed reasoning
+- **Type**: scenario
+- **Disposition**: new
+- **Harness**: httptest SSE mock with reasoning_content deltas then content deltas
+- **Preconditions**: Same mock as test 3.
+- **Actions**: Call `a.Stream()`, drain events, capture the FINISH event's `Response`.
+- **Expected outcome**:
+  - `finalResp.ReasoningText()` equals the full reasoning string.
+  - `finalResp.Text()` equals the full content string.
+  - `finalResp.Message.Content` has a ContentThinking part followed by a ContentText part.
+  - Source: unified spec (Response.ReasoningText(), Message content ordering).
+- **Interactions**: Tests the `[DONE]` handler's message assembly. Verifies that the streaming reasoning buffer is correctly accumulated and included in the final response.
+
+### 5. Streaming: reasoning_content followed by tool_calls (no text) emits REASONING_END before TOOL_CALL_START
+
+- **Name**: Reasoning followed by tool call without intervening text closes reasoning before tool call starts
+- **Type**: boundary
+- **Disposition**: new
+- **Harness**: httptest SSE mock sending reasoning_content deltas then tool_call deltas (no content deltas)
+- **Preconditions**: Adapter with no quirks. Mock SSE server sends reasoning_content deltas, then a tool_call chunk, then finish_reason tool_calls, then `[DONE]`.
+- **Actions**: Call `a.Stream()`, drain events, record event types.
+- **Expected outcome**:
+  - `REASONING_END` appears in the event sequence before `TOOL_CALL_START`.
+  - No `TEXT_START` or `TEXT_DELTA` events appear.
+  - The FINISH response contains a ContentThinking part and a ContentToolCall part (no ContentText).
+  - Source: Kimi K2.5 docs (reasoning_content precedes tool_calls), plan design decision (REASONING_END before TOOL_CALL_START, matching Anthropic's event ordering).
+- **Interactions**: Tests the edge case where reasoning transitions directly to tool calls. This is the bug caught by the plan-editor (missing REASONING_END before tool calls).
+
+### 6. Round-trip: ContentThinking serialized as reasoning_content in outgoing assistant messages
+
+- **Name**: Multi-turn conversation preserves reasoning_content from previous assistant turns
+- **Type**: scenario
+- **Disposition**: new
+- **Harness**: httptest mock that captures the request body and returns a simple response
+- **Preconditions**: Adapter with no quirks. Request includes a previous assistant message with ContentThinking + ContentText parts, followed by a user message.
+- **Actions**: Call `a.Complete()` with the multi-turn conversation.
+- **Expected outcome**:
+  - The captured request body's assistant message has `"reasoning_content"` set to the ThinkingData text.
+  - The assistant message's `"content"` is set to the text part.
+  - Source: Kimi K2.5 docs (reasoning_content must be preserved in assistant tool-call turns), plan design decision D6.
+- **Interactions**: Tests `toChatMessages` serialization for the `RoleAssistant` case.
+
+### 7. Round-trip: assistant message without thinking has no reasoning_content field
+
+- **Name**: Assistant message without ContentThinking omits reasoning_content from outgoing JSON
+- **Type**: regression
+- **Disposition**: new
+- **Harness**: httptest mock that captures request body
+- **Preconditions**: Adapter with no quirks. Request includes a previous assistant message with only ContentText (no thinking).
+- **Actions**: Call `a.Complete()` with the conversation.
+- **Expected outcome**:
+  - The captured assistant message JSON does NOT contain a `"reasoning_content"` key.
+  - Source: reasoning_content is optional and should only appear when thinking was present.
+- **Interactions**: Guards against adding spurious reasoning_content to all assistant messages.
+
+### 8. Usage: native reasoning_tokens from completion_tokens_details
+
+- **Name**: ReasoningTokens populated from native completion_tokens_details.reasoning_tokens
+- **Type**: unit
+- **Disposition**: new
+- **Harness**: httptest mock returning usage with `completion_tokens_details.reasoning_tokens`
+- **Preconditions**: Adapter with no quirks. Mock response includes `"usage": {"prompt_tokens": 10, "completion_tokens": 50, "total_tokens": 60, "completion_tokens_details": {"reasoning_tokens": 35}}` and reasoning_content.
+- **Actions**: Call `a.Complete()`.
+- **Expected outcome**:
+  - `resp.Usage.ReasoningTokens` is non-nil and equals 35.
+  - Source: Kimi K2.5 docs (completion_tokens_details.reasoning_tokens), unified spec (Usage.ReasoningTokens).
+- **Interactions**: Tests the native reasoning token extraction path in `fromChatCompletionResponse`.
+
+### 9. Usage: estimated reasoning_tokens when native count absent
+
+- **Name**: ReasoningTokens estimated from reasoning_content length when native count is absent
+- **Type**: unit
+- **Disposition**: new
+- **Harness**: httptest mock returning usage WITHOUT completion_tokens_details but WITH reasoning_content
+- **Preconditions**: Adapter with no quirks. Mock response has reasoning_content of known length (e.g., 80 chars) but no reasoning_tokens in usage.
+- **Actions**: Call `a.Complete()`.
+- **Expected outcome**:
+  - `resp.Usage.ReasoningTokens` is non-nil and equals `len(reasoning_content) / 4` (e.g., 80/4 = 20).
+  - Source: Anthropic adapter reference (chars/4 heuristic at `adapter.go:694-706`), plan design decision D7.
+- **Interactions**: Tests the estimation fallback path. Uses the same heuristic as the Anthropic adapter.
+
+### 10. ProviderQuirks: locked temperature and top_p stripped from request
+
+- **Name**: Quirks with LockTemperature and LockTopP remove those fields from the API request
+- **Type**: scenario
+- **Disposition**: new
+- **Harness**: httptest mock that captures request body
+- **Preconditions**: Adapter with `Quirks: ProviderQuirks{LockTemperature: true, LockTopP: true}`. Request has Temperature and TopP set.
+- **Actions**: Call `a.Complete()`.
+- **Expected outcome**:
+  - Captured request body does NOT contain `"temperature"` key.
+  - Captured request body does NOT contain `"top_p"` key.
+  - Source: Kimi K2.5 docs (temperature, top_p are fixed for K2.5), plan design decision D3.
+- **Interactions**: Tests `buildRequestBody` quirk application. Verifies that the quirk system interacts correctly with the existing parameter serialization.
+
+### 11. ProviderQuirks: locked frequency_penalty and presence_penalty stripped
+
+- **Name**: Quirks with LockFrequencyPenalty and LockPresencePenalty remove those fields from the API request
+- **Type**: unit
+- **Disposition**: new
+- **Harness**: httptest mock that captures request body
+- **Preconditions**: Adapter with all four lock quirks enabled. Request sets frequency_penalty and presence_penalty via ProviderOptions passthrough (since Request doesn't have dedicated fields for these, or if it does, via the appropriate field).
+- **Actions**: Call `a.Complete()`.
+- **Expected outcome**:
+  - Captured request body does NOT contain `"frequency_penalty"` or `"presence_penalty"` keys.
+  - Source: Kimi K2.5 docs (all four params are fixed).
+- **Interactions**: Tests additional locked parameter paths in `buildRequestBody`.
+
+### 12. ProviderQuirks: ToolChoiceAutoOnly clamps required to auto
+
+- **Name**: Quirks with ToolChoiceAutoOnly downgrades tool_choice "required" to "auto"
+- **Type**: scenario
+- **Disposition**: new
+- **Harness**: httptest mock that captures request body
+- **Preconditions**: Adapter with `Quirks: ProviderQuirks{ToolChoiceAutoOnly: true}`. Request has `ToolChoice.Mode = "required"` and tools defined.
+- **Actions**: Call `a.Complete()`.
+- **Expected outcome**:
+  - Captured request body has `"tool_choice": "auto"` (not "required").
+  - Source: Kimi K2.5 docs (tool_choice restricted to auto/none with thinking), GLM 5.0 docs (only auto supported).
+- **Interactions**: Tests `buildRequestBody` tool_choice quirk. Interacts with `toChatToolChoice` output.
+
+### 13. ProviderQuirks: ToolChoiceAutoOnly preserves auto and none
+
+- **Name**: Quirks with ToolChoiceAutoOnly allows "auto" and "none" through unchanged
+- **Type**: boundary
+- **Disposition**: new
+- **Harness**: httptest mock that captures request body
+- **Preconditions**: Adapter with `ToolChoiceAutoOnly: true`. Request has `ToolChoice.Mode = "auto"`.
+- **Actions**: Call `a.Complete()`.
+- **Expected outcome**:
+  - Captured request body has `"tool_choice": "auto"` (unchanged).
+  - Source: Both Kimi and GLM accept auto/none.
+- **Interactions**: Guards against over-clamping valid values.
+
+### 14. ProviderQuirks: MaxStopSequences truncates stop array
+
+- **Name**: Quirks with MaxStopSequences=1 truncates stop sequences to first entry
+- **Type**: scenario
+- **Disposition**: new
+- **Harness**: httptest mock that captures request body
+- **Preconditions**: Adapter with `Quirks: ProviderQuirks{MaxStopSequences: 1}`. Request has 3 stop sequences.
+- **Actions**: Call `a.Complete()`.
+- **Expected outcome**:
+  - Captured request body `"stop"` array has exactly 1 element (the first one).
+  - Source: GLM 5.0 docs (max 1 stop sequence).
+- **Interactions**: Tests `buildRequestBody` stop sequence quirk.
+
+### 15. ProviderQuirks: NoJSONSchema downgrades response_format
+
+- **Name**: Quirks with NoJSONSchema downgrades json_schema to json_object
+- **Type**: scenario
+- **Disposition**: new
+- **Harness**: httptest mock that captures request body
+- **Preconditions**: Adapter with `Quirks: ProviderQuirks{NoJSONSchema: true}`. Request has `ResponseFormat.Type = "json_schema"`.
+- **Actions**: Call `a.Complete()`.
+- **Expected outcome**:
+  - Captured request body `"response_format"` has `"type": "json_object"` (not json_schema).
+  - The json_schema property is removed.
+  - Source: Both Kimi and GLM docs (no json_schema support).
+- **Interactions**: Tests `buildRequestBody` response format quirk.
+
+### 16. ProviderQuirks: StripEmptyContent removes empty text parts
+
+- **Name**: Quirks with StripEmptyContent filters empty text parts from user messages
+- **Type**: scenario
+- **Disposition**: new
+- **Harness**: httptest mock that captures request body
+- **Preconditions**: Adapter with `Quirks: ProviderQuirks{StripEmptyContent: true}`. Request has a user message with an empty text part and a non-empty text part.
+- **Actions**: Call `a.Complete()`.
+- **Expected outcome**:
+  - The captured user message content equals only the non-empty text (empty part stripped).
+  - Source: GLM 5.0 docs (API rejects messages with empty content[].text).
+- **Interactions**: Tests `toChatMessages` empty content filtering. Interacts with `textFromParts` or its replacement.
+
+### 17. ProviderQuirks: FinishReasonMap translates non-standard finish reasons (non-streaming)
+
+- **Name**: Non-streaming response with quirk-mapped finish reason "sensitive" becomes "content_filter"
+- **Type**: scenario
+- **Disposition**: new
+- **Harness**: httptest mock returning `"finish_reason": "sensitive"`
+- **Preconditions**: Adapter with `Quirks: ProviderQuirks{FinishReasonMap: map[string]string{"sensitive": "content_filter", "network_error": "error"}}`.
+- **Actions**: Call `a.Complete()`.
+- **Expected outcome**:
+  - `resp.Finish.Reason` equals `"content_filter"`.
+  - `resp.Finish.Raw` equals `"sensitive"` (original provider value preserved).
+  - Source: GLM 5.0 docs (sensitive finish reason), plan design decision D5 (localized mapping, raw preserved).
+- **Interactions**: Tests `fromChatCompletionResponse` finish reason mapping. This is the bug caught by the plan-editor (Raw must preserve the original provider value, not the mapped one).
+
+### 18. ProviderQuirks: FinishReasonMap in streaming
+
+- **Name**: Streaming finish event with quirk-mapped finish reason preserves original in Raw
+- **Type**: scenario
+- **Disposition**: new
+- **Harness**: httptest SSE mock with `"finish_reason": "sensitive"` in the last chunk
+- **Preconditions**: Adapter with GLM quirk preset (includes FinishReasonMap).
+- **Actions**: Call `a.Stream()`, drain events, capture FINISH event.
+- **Expected outcome**:
+  - FINISH event's `FinishReason.Reason` equals `"content_filter"`.
+  - FINISH event's `FinishReason.Raw` equals `"sensitive"`.
+  - Source: Same as test 17, but for the streaming path.
+- **Interactions**: Tests the streaming [DONE] handler's finish reason mapping. Verifies parity between streaming and non-streaming quirk behavior.
+
+### 19. Named preset: QuirksPreset("kimi-k2.5") returns correct configuration
+
+- **Name**: QuirksPreset for kimi-k2.5 enables all Kimi-specific quirk flags
+- **Type**: unit
+- **Disposition**: new
+- **Harness**: Direct function call (no HTTP)
+- **Preconditions**: None.
+- **Actions**: Call `QuirksPreset("kimi-k2.5")`.
+- **Expected outcome**:
+  - `LockTemperature`, `LockTopP`, `LockFrequencyPenalty`, `LockPresencePenalty` are all true.
+  - `ToolChoiceAutoOnly` is true.
+  - `NoJSONSchema` is true.
+  - Source: Kimi K2.5 API docs (all these restrictions documented).
+- **Interactions**: None. Pure function test.
+
+### 20. Named preset: QuirksPreset("glm-5") returns correct configuration
+
+- **Name**: QuirksPreset for glm-5 enables all GLM-specific quirk flags
+- **Type**: unit
+- **Disposition**: new
+- **Harness**: Direct function call (no HTTP)
+- **Preconditions**: None.
+- **Actions**: Call `QuirksPreset("glm-5")`.
+- **Expected outcome**:
+  - `StripEmptyContent` is true.
+  - `ToolChoiceAutoOnly` is true.
+  - `MaxStopSequences` equals 1.
+  - `NoJSONSchema` is true.
+  - `FinishReasonMap["sensitive"]` equals `"content_filter"`.
+  - `FinishReasonMap["network_error"]` equals `"error"`.
+  - Source: GLM 5.0 API docs (all these restrictions documented).
+- **Interactions**: None. Pure function test.
+
+### 21. Named preset: unknown provider returns zero-value quirks
+
+- **Name**: QuirksPreset for unknown provider name returns empty/default quirks
+- **Type**: boundary
+- **Disposition**: new
+- **Harness**: Direct function call
+- **Preconditions**: None.
+- **Actions**: Call `QuirksPreset("unknown-provider")`.
+- **Expected outcome**:
+  - All boolean fields are false, `MaxStopSequences` is 0, `FinishReasonMap` is nil.
+  - Source: Plan Task 7 (unknown names return zero-value quirks).
+- **Interactions**: None.
+
+### 22. Env var: OPENAI_COMPATIBLE_PROVIDER_QUIRKS configures adapter quirks
+
+- **Name**: NewFromEnv reads OPENAI_COMPATIBLE_PROVIDER_QUIRKS env var and applies preset
+- **Type**: scenario
+- **Disposition**: new
+- **Harness**: `t.Setenv` to configure env vars, then call `NewFromEnv()`
+- **Preconditions**: OPENAI_COMPATIBLE_BASE_URL, OPENAI_COMPATIBLE_API_KEY, and OPENAI_COMPATIBLE_PROVIDER_QUIRKS set.
+- **Actions**: Call `NewFromEnv()`.
+- **Expected outcome**:
+  - Returned adapter has `Quirks.LockTemperature == true` (from kimi-k2.5 preset).
+  - Returned adapter has `Quirks.ToolChoiceAutoOnly == true`.
+  - Source: Plan Task 7 (env var parsing), plan design decision D3.
+- **Interactions**: Tests the `NewFromEnv` initialization path. Interacts with the `init()` auto-registration.
+
+### 23. Integration: Kimi K2.5 multi-turn reasoning with tool call
+
+- **Name**: Full Kimi K2.5 conversation: user question, reasoning+tool call, tool result, reasoning+answer
+- **Type**: integration
+- **Disposition**: new
+- **Harness**: httptest mock with request counter serving different responses per call
+- **Preconditions**: Adapter with `QuirksPreset("kimi-k2.5")`. Temperature set on request.
+- **Actions**:
+  1. First `a.Complete()`: user asks question. Mock returns reasoning_content + tool_call.
+  2. Second `a.Complete()`: send original user message, previous assistant response (with ContentThinking + ContentToolCall), tool result. Mock returns reasoning_content + content.
+- **Expected outcome**:
+  - First request body: no `"temperature"` key (locked).
+  - First response: `ReasoningText()` matches, `ToolCalls()` has 1 call, `Usage.ReasoningTokens` is 20 (native).
+  - Second request body: assistant message has `"reasoning_content"` round-tripped.
+  - Second response: `ReasoningText()` matches, `Text()` matches, `Usage.ReasoningTokens` is estimated (no native count).
+  - Source: Kimi K2.5 docs (reasoning_content preservation, locked params), plan Task 9.
+- **Interactions**: End-to-end test exercising reasoning parsing, round-tripping, quirk application, and usage tracking together. This is the highest-fidelity non-live test for the Kimi path.
+
+### 24. Integration: GLM 5.0 empty content stripping and sensitive filter
+
+- **Name**: Full GLM 5.0 conversation with empty content parts, stop truncation, and sensitive finish
+- **Type**: integration
+- **Disposition**: new
+- **Harness**: httptest mock that captures request body and returns sensitive finish
+- **Preconditions**: Adapter with `QuirksPreset("glm-5")`. Request has user message with empty + non-empty text parts and 3 stop sequences.
+- **Actions**: Call `a.Complete()`.
+- **Expected outcome**:
+  - Captured request body: stop array has 1 element (truncated).
+  - Captured request body: user message content is "tell me something" (empty part stripped).
+  - `resp.Finish.Reason` equals `"content_filter"` (mapped from sensitive).
+  - Source: GLM 5.0 docs (empty content rejection, stop limit, finish reasons), plan Task 9.
+- **Interactions**: End-to-end test exercising multiple GLM quirks together in a single request.
+
+### 25. Regression: all 24 existing tests pass unchanged
+
+- **Name**: Existing openaicompat test suite continues to pass with no modifications
+- **Type**: regression
+- **Disposition**: existing
+- **Harness**: `go test -count=1 ./llm/providers/openaicompat/`
+- **Preconditions**: All implementation changes applied.
+- **Actions**: Run the full test suite.
+- **Expected outcome**:
+  - All 24 existing tests pass. No test function names changed, no test logic modified.
+  - Source: Regression baseline requirement from testing strategy.
+- **Interactions**: Validates that reasoning_content parsing (unconditional) and ProviderQuirks (zero-value by default) do not affect existing behavior.
+
+### 26. Build verification: project compiles and all tests pass
+
+- **Name**: Full project builds and passes go vet and all tests
+- **Type**: invariant
+- **Disposition**: new
+- **Harness**: `make build && go vet ./... && go test -short -count=1 ./...`
+- **Preconditions**: All implementation changes applied.
+- **Actions**: Run build, vet, and full test suite.
+- **Expected outcome**:
+  - Build succeeds with no errors.
+  - No vet warnings.
+  - All tests across all packages pass.
+  - Source: Standard CI gate.
+- **Interactions**: Catches compilation errors, import cycles, or cross-package regressions.
+
+---
+
+## Coverage Summary
+
+### Covered
+
+| Area | Tests | Coverage |
+|------|-------|----------|
+| **reasoning_content parsing (non-streaming)** | 1, 2 | With and without reasoning_content |
+| **reasoning_content streaming events** | 3, 4, 5 | Text follow-up, tool-call follow-up, final response assembly |
+| **reasoning_content round-tripping** | 6, 7 | With and without thinking content |
+| **Reasoning token tracking** | 8, 9 | Native extraction and estimation fallback |
+| **Locked hyperparameters** | 10, 11 | All four lockable params |
+| **ToolChoice restriction** | 12, 13 | Clamping and passthrough |
+| **Stop sequence truncation** | 14 | GLM limit |
+| **JSON schema downgrade** | 15 | json_schema to json_object |
+| **Empty content stripping** | 16 | GLM empty text rejection |
+| **Finish reason mapping** | 17, 18 | Non-streaming and streaming, Raw preservation |
+| **Named presets** | 19, 20, 21 | kimi-k2.5, glm-5, unknown |
+| **Env var configuration** | 22 | OPENAI_COMPATIBLE_PROVIDER_QUIRKS |
+| **End-to-end integration** | 23, 24 | Kimi multi-turn, GLM quirk combo |
+| **Regression baseline** | 25 | All 24 existing tests |
+| **Build verification** | 26 | Compilation, vet, cross-package |
+
+### Explicitly Excluded
+
+| Area | Reason | Risk |
+|------|--------|------|
+| **Live API calls to Kimi/GLM** | Requires API keys not available in test environment. Per agreed strategy, mock tests cover documented response shapes. | Moderate: real API may have undocumented quirks. Mitigated by basing mocks on actual API documentation. |
+| **Thinking parameter injection** | Flows through existing `ProviderOptions` passthrough (design decision D4), which is already tested by `TestAdapter_Complete_MapsToChatCompletionsAPI` and the provider options passthrough code path. No new code needed. | Low: passthrough mechanism is generic and proven. |
+| **`video_url` content type** | Kimi-specific, out of scope for this task per user description. | Low: no user demand, no implementation planned. |
+| **`do_sample` GLM parameter** | GLM-specific, flows through ProviderOptions passthrough. | Low: same passthrough mechanism. |
+| **Performance benchmarks** | All changes are in JSON parsing and map operations, which are fast by nature. No performance-critical paths modified. | Low: no measurable performance risk from these changes. |

--- a/docs/plans/2026-03-23-openaicompat-reasoning.md
+++ b/docs/plans/2026-03-23-openaicompat-reasoning.md
@@ -1,0 +1,1505 @@
+# OpenAI-Compatible Adapter: Reasoning Content & Provider Quirk Support
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use trycycle-executing to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the `openaicompat` adapter to parse and emit `reasoning_content` (the de facto standard for reasoning output from Kimi K2.5, GLM 5.0, DeepSeek, QwQ, etc.) and add a per-provider quirk configuration system that handles locked hyperparameters, tool_choice restrictions, empty content stripping, non-standard finish reasons, and stop sequence limits.
+
+**Architecture:** The `reasoning_content` field appears in both non-streaming assistant messages and streaming delta chunks, alongside the standard `content` field. We add parsing for this field into the existing `chatMessage`/`chatDelta` types, emit the unified `ContentThinking` / `StreamEventReasoning*` events that the rest of the codebase already understands, and serialize `ContentThinking` parts back as `reasoning_content` in outgoing assistant messages. Provider-specific quirks are expressed as a `ProviderQuirks` struct that `buildRequestBody` consults to strip/clamp/transform request parameters before serialization.
+
+**Tech Stack:** Go, `net/http`, `encoding/json`, `httptest` (tests)
+
+---
+
+## Design Decisions
+
+### D1: Why extend `openaicompat` instead of creating new provider adapters
+
+The Kimi K2.5 and GLM 5.0 APIs are Chat Completions compatible. Their deviations are small, well-enumerated quirks — not fundamental protocol differences. Creating separate adapters would duplicate ~90% of the code. A quirk configuration system inside `openaicompat` is cleaner, has a single SSE parser to maintain, and naturally extends to future providers (DeepSeek R1, QwQ, etc.) that use the same `reasoning_content` pattern.
+
+### D2: `reasoning_content` is parsed unconditionally, not gated by quirk config
+
+The `reasoning_content` field is harmless when absent (just an empty string in the JSON). Parsing it unconditionally means any OpenAI-compatible provider that starts emitting reasoning content will work automatically — no configuration required. This matches how the adapter already handles optional fields like `tool_calls`.
+
+### D3: Quirks are configured at `Adapter` construction time, not per-request
+
+The quirks apply to the remote API endpoint, not to individual requests. Configuring them on the `Adapter` struct (populated from env vars or programmatic construction) keeps `buildRequestBody` simple and avoids per-request overhead. A new env var `OPENAI_COMPATIBLE_PROVIDER_QUIRKS` accepts a comma-separated list of named quirk presets (e.g., `kimi-k2.5`, `glm-5`) or individual quirk flags (e.g., `lock-temperature,lock-top-p,tool-choice-auto-only`).
+
+### D4: Thinking parameter injection uses `ProviderOptions` passthrough
+
+The Kimi `"thinking": {"type": "enabled"}` and GLM `"thinking": {"type": "enabled", "clear_thinking": true}` parameters are provider-specific. Rather than adding thinking-parameter-injection to the core quirks system, they flow through the existing `ProviderOptions["openai-compatible"]` passthrough mechanism. Users who want thinking enabled pass the appropriate JSON. This avoids the adapter needing to know the exact shape of every provider's thinking parameter. The plan includes documentation of this in the adapter's env var help text.
+
+### D5: Non-standard finish reasons are mapped via a quirk-specific translation table
+
+GLM returns `"sensitive"` and `"network_error"` as finish reasons. Rather than adding these to the global `NormalizeFinishReason` function (which would affect all providers), the quirk config includes a `FinishReasonMap` that the adapter consults before falling through to the default normalization. This keeps the mapping localized and explicit.
+
+### D6: `reasoning_content` round-trip in assistant messages
+
+When the adapter builds outgoing messages and encounters a `ContentThinking` part, it serializes it as `reasoning_content` on the assistant message. This is required because Kimi K2.5 documents that `reasoning_content` from assistant tool-call turns must be preserved in subsequent messages. GLM likely has the same requirement. The serialization is straightforward — a single field on the message JSON object.
+
+### D7: Usage.ReasoningTokens estimation from reasoning_content
+
+Both Kimi and GLM may include `completion_tokens_details.reasoning_tokens` in usage. The adapter checks for this first (native count). If absent but `reasoning_content` was present in the response, it estimates using the same chars/4 heuristic the Anthropic adapter uses. This ensures `Usage.ReasoningTokens` is always populated when reasoning happened.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `llm/providers/openaicompat/adapter.go` | All changes: struct types, request building, response parsing, streaming, quirk system |
+| `llm/providers/openaicompat/adapter_test.go` | All new tests: reasoning parsing, quirk behavior, round-tripping |
+
+No new files are created. All changes land in the existing two files, following the established pattern.
+
+---
+
+### Task 1: Add `reasoning_content` to response type structs
+
+**Files:**
+- Modify: `llm/providers/openaicompat/adapter.go:617-651` (chatMessage, chatDelta types)
+
+- [ ] **Step 1: Identify or write the failing test**
+
+Write a test that sends a non-streaming request and receives a response with `reasoning_content` alongside `content`. Assert that the response contains a `ContentThinking` part with the reasoning text, followed by a `ContentText` part.
+
+```go
+func TestComplete_ReasoningContent_ParsedAsThinking(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{
+  "id": "chatcmpl-rc1",
+  "model": "kimi-k2.5",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "reasoning_content": "Let me think step by step...\nFirst, I need to consider...",
+      "content": "The answer is 42."
+    },
+    "finish_reason": "stop"
+  }],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 50, "total_tokens": 60}
+}`))
+    }))
+    t.Cleanup(srv.Close)
+
+    a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+    resp, err := a.Complete(context.Background(), llm.Request{
+        Model:    "kimi-k2.5",
+        Messages: []llm.Message{llm.User("What is the meaning of life?")},
+    })
+    if err != nil {
+        t.Fatalf("Complete: %v", err)
+    }
+
+    // Should have thinking content first, then text.
+    if len(resp.Message.Content) < 2 {
+        t.Fatalf("expected at least 2 content parts, got %d: %+v", len(resp.Message.Content), resp.Message.Content)
+    }
+    if resp.Message.Content[0].Kind != llm.ContentThinking {
+        t.Fatalf("first part kind: %v, want thinking", resp.Message.Content[0].Kind)
+    }
+    if resp.Message.Content[0].Thinking == nil || resp.Message.Content[0].Thinking.Text != "Let me think step by step...\nFirst, I need to consider..." {
+        t.Fatalf("thinking text: %+v", resp.Message.Content[0].Thinking)
+    }
+    if resp.Message.Content[1].Kind != llm.ContentText {
+        t.Fatalf("second part kind: %v, want text", resp.Message.Content[1].Kind)
+    }
+    if resp.Message.Content[1].Text != "The answer is 42." {
+        t.Fatalf("text: %q", resp.Message.Content[1].Text)
+    }
+    if resp.ReasoningText() != "Let me think step by step...\nFirst, I need to consider..." {
+        t.Fatalf("ReasoningText(): %q", resp.ReasoningText())
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestComplete_ReasoningContent_ParsedAsThinking -v ./llm/providers/openaicompat/`
+Expected: FAIL — `chatMessage` struct has no `ReasoningContent` field; `fromChatCompletionResponse` does not parse it.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `ReasoningContent` field to the `chatMessage` struct:
+
+```go
+type chatMessage struct {
+    Role             string         `json:"role"`
+    Content          string         `json:"content"`
+    ReasoningContent string         `json:"reasoning_content,omitempty"`
+    ToolCalls        []chatToolCall `json:"tool_calls,omitempty"`
+}
+```
+
+Update `fromChatCompletionResponse` to emit a `ContentThinking` part before the text part when `ReasoningContent` is non-empty:
+
+```go
+// In fromChatCompletionResponse, replace the current parts-building block:
+parts := []llm.ContentPart{}
+if choice.Message.ReasoningContent != "" {
+    parts = append(parts, llm.ContentPart{
+        Kind:     llm.ContentThinking,
+        Thinking: &llm.ThinkingData{Text: choice.Message.ReasoningContent},
+    })
+}
+if choice.Message.Content != "" {
+    parts = append(parts, llm.ContentPart{Kind: llm.ContentText, Text: choice.Message.Content})
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run TestComplete_ReasoningContent_ParsedAsThinking -v ./llm/providers/openaicompat/`
+Expected: PASS
+
+- [ ] **Step 5: Refactor and verify**
+
+Run full suite to confirm no regression:
+Run: `go test -count=1 ./llm/providers/openaicompat/`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning add llm/providers/openaicompat/adapter.go llm/providers/openaicompat/adapter_test.go
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning commit -m "feat(openaicompat): parse reasoning_content in non-streaming responses"
+```
+
+---
+
+### Task 2: Add `reasoning_content` streaming support
+
+**Files:**
+- Modify: `llm/providers/openaicompat/adapter.go:647-651` (chatDelta type), `adapter.go:191-343` (Stream goroutine)
+- Test: `llm/providers/openaicompat/adapter_test.go`
+
+- [ ] **Step 1: Identify or write the failing test**
+
+Write a streaming test where the server returns chunks with `reasoning_content` deltas before `content` deltas. Assert that `REASONING_START`, `REASONING_DELTA`, `REASONING_END` events are emitted in the correct order, followed by `TEXT_START`, `TEXT_DELTA`, `TEXT_END`.
+
+```go
+func TestStream_ReasoningContent_EmitsReasoningEvents(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "text/event-stream")
+        flusher, _ := w.(http.Flusher)
+
+        chunks := []string{
+            // Reasoning content deltas come first.
+            `{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Let me "},"finish_reason":null}]}`,
+            `{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"reasoning_content":"think..."},"finish_reason":null}]}`,
+            // Then text content.
+            `{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"content":"The answer"},"finish_reason":null}]}`,
+            `{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"content":" is 42."},"finish_reason":null}]}`,
+            `{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":20,"total_tokens":25}}`,
+        }
+        for _, c := range chunks {
+            fmt.Fprintf(w, "data: %s\n\n", c)
+            flusher.Flush()
+        }
+        fmt.Fprintf(w, "data: [DONE]\n\n")
+        flusher.Flush()
+    }))
+    t.Cleanup(srv.Close)
+
+    a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+
+    st, err := a.Stream(ctx, llm.Request{
+        Model:    "kimi-k2.5",
+        Messages: []llm.Message{llm.User("What is the meaning of life?")},
+    })
+    if err != nil {
+        t.Fatalf("Stream: %v", err)
+    }
+    defer st.Close()
+
+    var kinds []llm.StreamEventType
+    var reasoningDeltas []string
+    var textDeltas []string
+    for ev := range st.Events() {
+        kinds = append(kinds, ev.Type)
+        if ev.Type == llm.StreamEventReasoningDelta {
+            reasoningDeltas = append(reasoningDeltas, ev.ReasoningDelta)
+        }
+        if ev.Type == llm.StreamEventTextDelta {
+            textDeltas = append(textDeltas, ev.Delta)
+        }
+    }
+
+    // Verify reasoning events.
+    if strings.Join(reasoningDeltas, "") != "Let me think..." {
+        t.Fatalf("reasoning deltas: %q", strings.Join(reasoningDeltas, ""))
+    }
+    if strings.Join(textDeltas, "") != "The answer is 42." {
+        t.Fatalf("text deltas: %q", strings.Join(textDeltas, ""))
+    }
+
+    // Verify event ordering: REASONING_START before REASONING_DELTA, REASONING_END before TEXT_START.
+    var reasoningStartIdx, reasoningEndIdx, textStartIdx int
+    for i, k := range kinds {
+        switch k {
+        case llm.StreamEventReasoningStart:
+            reasoningStartIdx = i
+        case llm.StreamEventReasoningEnd:
+            reasoningEndIdx = i
+        case llm.StreamEventTextStart:
+            textStartIdx = i
+        }
+    }
+    if reasoningStartIdx >= reasoningEndIdx {
+        t.Fatalf("REASONING_START (%d) should come before REASONING_END (%d)", reasoningStartIdx, reasoningEndIdx)
+    }
+    if reasoningEndIdx >= textStartIdx {
+        t.Fatalf("REASONING_END (%d) should come before TEXT_START (%d)", reasoningEndIdx, textStartIdx)
+    }
+
+    // Verify the final response includes thinking content.
+    var finalResp *llm.Response
+    for ev := range st.Events() {
+        if ev.Type == llm.StreamEventFinish && ev.Response != nil {
+            finalResp = ev.Response
+        }
+    }
+    // The stream is already drained. Re-check from kinds for FINISH.
+    // Actually, we need to capture it in the loop above.
+}
+```
+
+Note: The test above should be refined to capture the FINISH event's response in the main loop. The implementation step will correct the test to capture the final response properly.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestStream_ReasoningContent_EmitsReasoningEvents -v ./llm/providers/openaicompat/`
+Expected: FAIL — `chatDelta` has no `ReasoningContent` field; streaming goroutine doesn't handle it.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `ReasoningContent` to `chatDelta`:
+
+```go
+type chatDelta struct {
+    Role             string              `json:"role"`
+    Content          string              `json:"content"`
+    ReasoningContent string              `json:"reasoning_content,omitempty"`
+    ToolCalls        []chatChunkToolCall `json:"tool_calls,omitempty"`
+}
+```
+
+In the streaming goroutine (inside the `ParseSSE` callback), add reasoning content handling before the text delta handling:
+
+```go
+// Track reasoning state alongside textStarted.
+var reasoningStarted bool
+var reasoningBuf strings.Builder
+
+// Inside the SSE callback, after choice is extracted:
+
+// Reasoning content delta (must be checked before text delta).
+if choice.Delta.ReasoningContent != "" {
+    if !reasoningStarted {
+        s.Send(llm.StreamEvent{Type: llm.StreamEventReasoningStart})
+        reasoningStarted = true
+    }
+    reasoningBuf.WriteString(choice.Delta.ReasoningContent)
+    s.Send(llm.StreamEvent{
+        Type:           llm.StreamEventReasoningDelta,
+        ReasoningDelta: choice.Delta.ReasoningContent,
+    })
+}
+
+// Text delta — if reasoning was active and text is now starting, close reasoning first.
+if choice.Delta.Content != "" {
+    if reasoningStarted && !textStarted {
+        s.Send(llm.StreamEvent{Type: llm.StreamEventReasoningEnd})
+    }
+    if !textStarted {
+        s.Send(llm.StreamEvent{Type: llm.StreamEventTextStart, TextID: "text_0"})
+        textStarted = true
+    }
+    textBuf.WriteString(choice.Delta.Content)
+    s.Send(llm.StreamEvent{
+        Type:   llm.StreamEventTextDelta,
+        TextID: "text_0",
+        Delta:  choice.Delta.Content,
+    })
+}
+```
+
+In the `[DONE]` handler, add reasoning content to the final response message and close reasoning if still open:
+
+```go
+// Before the existing text end/tool call end handling in [DONE]:
+if reasoningStarted && !textStarted {
+    // Reasoning was never followed by text — close it now.
+    s.Send(llm.StreamEvent{Type: llm.StreamEventReasoningEnd})
+}
+
+// In the final message building:
+msg := llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{}}
+if reasoningBuf.Len() > 0 {
+    msg.Content = append(msg.Content, llm.ContentPart{
+        Kind:     llm.ContentThinking,
+        Thinking: &llm.ThinkingData{Text: reasoningBuf.String()},
+    })
+}
+if textBuf.Len() > 0 {
+    msg.Content = append(msg.Content, llm.ContentPart{Kind: llm.ContentText, Text: textBuf.String()})
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run TestStream_ReasoningContent_EmitsReasoningEvents -v ./llm/providers/openaicompat/`
+Expected: PASS
+
+- [ ] **Step 5: Refactor and verify**
+
+Clean up the test (remove the dead second `range st.Events()` loop, capture FINISH response in the main loop). Run full suite:
+Run: `go test -count=1 ./llm/providers/openaicompat/`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning add llm/providers/openaicompat/adapter.go llm/providers/openaicompat/adapter_test.go
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning commit -m "feat(openaicompat): emit reasoning events from streaming reasoning_content"
+```
+
+---
+
+### Task 3: Round-trip `reasoning_content` in outgoing assistant messages
+
+**Files:**
+- Modify: `llm/providers/openaicompat/adapter.go:407-464` (toChatMessages, RoleAssistant case)
+- Test: `llm/providers/openaicompat/adapter_test.go`
+
+- [ ] **Step 1: Identify or write the failing test**
+
+Write a test that sends a multi-turn conversation where a previous assistant message has `ContentThinking` parts. Assert that the outgoing JSON request includes `reasoning_content` on the assistant message.
+
+```go
+func TestComplete_ThinkingContentRoundTripped_AsReasoningContent(t *testing.T) {
+    var gotBody map[string]any
+
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        b, _ := io.ReadAll(r.Body)
+        _ = json.Unmarshal(b, &gotBody)
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{
+  "id": "chatcmpl-rt1",
+  "model": "kimi-k2.5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "OK"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}
+}`))
+    }))
+    t.Cleanup(srv.Close)
+
+    a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+    _, err := a.Complete(context.Background(), llm.Request{
+        Model: "kimi-k2.5",
+        Messages: []llm.Message{
+            llm.User("What is 2+2?"),
+            {Role: llm.RoleAssistant, Content: []llm.ContentPart{
+                {Kind: llm.ContentThinking, Thinking: &llm.ThinkingData{Text: "I need to add 2 and 2."}},
+                {Kind: llm.ContentText, Text: "The answer is 4."},
+            }},
+            llm.User("Are you sure?"),
+        },
+    })
+    if err != nil {
+        t.Fatalf("Complete: %v", err)
+    }
+
+    msgs, _ := gotBody["messages"].([]any)
+    if len(msgs) != 3 {
+        t.Fatalf("messages count: %d", len(msgs))
+    }
+    assistantMsg, _ := msgs[1].(map[string]any)
+    rc, ok := assistantMsg["reasoning_content"].(string)
+    if !ok || rc != "I need to add 2 and 2." {
+        t.Fatalf("reasoning_content: %v (ok=%v)", assistantMsg["reasoning_content"], ok)
+    }
+    content, _ := assistantMsg["content"].(string)
+    if content != "The answer is 4." {
+        t.Fatalf("content: %v", assistantMsg["content"])
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestComplete_ThinkingContentRoundTripped_AsReasoningContent -v ./llm/providers/openaicompat/`
+Expected: FAIL — `toChatMessages` ignores `ContentThinking` parts for assistant messages.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `toChatMessages`, update the `RoleAssistant` case to extract thinking content and serialize it as `reasoning_content`:
+
+```go
+case llm.RoleAssistant:
+    msg := map[string]any{
+        "role": "assistant",
+    }
+    text := textFromParts(m.Content)
+    calls := toolCallsFromParts(m.Content)
+    reasoning := thinkingFromParts(m.Content)
+    if reasoning != "" {
+        msg["reasoning_content"] = reasoning
+    }
+    if len(calls) > 0 {
+        msg["tool_calls"] = calls
+        if text != "" {
+            msg["content"] = text
+        }
+    } else {
+        msg["content"] = text
+    }
+    out = append(out, msg)
+```
+
+Add a helper function:
+
+```go
+func thinkingFromParts(parts []llm.ContentPart) string {
+    var b strings.Builder
+    for _, p := range parts {
+        if p.Kind == llm.ContentThinking && p.Thinking != nil && p.Thinking.Text != "" {
+            if b.Len() > 0 {
+                b.WriteString("\n")
+            }
+            b.WriteString(p.Thinking.Text)
+        }
+    }
+    return b.String()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run TestComplete_ThinkingContentRoundTripped_AsReasoningContent -v ./llm/providers/openaicompat/`
+Expected: PASS
+
+- [ ] **Step 5: Refactor and verify**
+
+Run full suite:
+Run: `go test -count=1 ./llm/providers/openaicompat/`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning add llm/providers/openaicompat/adapter.go llm/providers/openaicompat/adapter_test.go
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning commit -m "feat(openaicompat): round-trip ContentThinking as reasoning_content in outgoing messages"
+```
+
+---
+
+### Task 4: Parse `reasoning_tokens` from usage and estimate when absent
+
+**Files:**
+- Modify: `llm/providers/openaicompat/adapter.go:660-717` (fromChatCompletionResponse usage section), `adapter.go:264-276` (streaming usage)
+- Test: `llm/providers/openaicompat/adapter_test.go`
+
+- [ ] **Step 1: Identify or write the failing test**
+
+Write two tests:
+1. A test where usage includes `completion_tokens_details.reasoning_tokens` — assert `Usage.ReasoningTokens` is populated with the native value.
+2. A test where usage does NOT include reasoning_tokens but the response has `reasoning_content` — assert `Usage.ReasoningTokens` is estimated from the content length.
+
+```go
+func TestComplete_ReasoningTokens_NativeFromUsage(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{
+  "id": "chatcmpl-u1",
+  "model": "kimi-k2.5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "reasoning_content": "thinking...", "content": "done"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 50, "total_tokens": 60, "completion_tokens_details": {"reasoning_tokens": 35}}
+}`))
+    }))
+    t.Cleanup(srv.Close)
+
+    a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+    resp, err := a.Complete(context.Background(), llm.Request{
+        Model:    "kimi-k2.5",
+        Messages: []llm.Message{llm.User("think")},
+    })
+    if err != nil {
+        t.Fatalf("Complete: %v", err)
+    }
+    if resp.Usage.ReasoningTokens == nil || *resp.Usage.ReasoningTokens != 35 {
+        t.Fatalf("ReasoningTokens: %v, want 35", resp.Usage.ReasoningTokens)
+    }
+}
+
+func TestComplete_ReasoningTokens_EstimatedFromContent(t *testing.T) {
+    // 80 characters of reasoning = 80/4 = 20 estimated tokens.
+    reasoning := strings.Repeat("abcd", 20) // 80 chars
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        fmt.Fprintf(w, `{
+  "id": "chatcmpl-u2",
+  "model": "glm-5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "reasoning_content": %q, "content": "done"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 50, "total_tokens": 60}
+}`, reasoning)
+    }))
+    t.Cleanup(srv.Close)
+
+    a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+    resp, err := a.Complete(context.Background(), llm.Request{
+        Model:    "glm-5",
+        Messages: []llm.Message{llm.User("think")},
+    })
+    if err != nil {
+        t.Fatalf("Complete: %v", err)
+    }
+    if resp.Usage.ReasoningTokens == nil || *resp.Usage.ReasoningTokens != 20 {
+        t.Fatalf("ReasoningTokens: %v, want 20", resp.Usage.ReasoningTokens)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run "TestComplete_ReasoningTokens" -v ./llm/providers/openaicompat/`
+Expected: FAIL — usage parsing doesn't check `completion_tokens_details.reasoning_tokens` and doesn't estimate.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `fromChatCompletionResponse`, after the existing usage parsing block, add reasoning token extraction:
+
+```go
+// After existing usage parsing:
+if parsed.Usage != nil {
+    // ... existing code ...
+
+    // Extract native reasoning tokens from completion_tokens_details.
+    if details, ok := parsed.Usage["completion_tokens_details"].(map[string]any); ok {
+        if rt := llm.IntFromAny(details["reasoning_tokens"]); rt > 0 {
+            resp.Usage.ReasoningTokens = &rt
+        }
+    }
+}
+
+// Estimate reasoning tokens from thinking content when not natively reported.
+if resp.Usage.ReasoningTokens == nil {
+    var thinkingChars int
+    for _, p := range parts {
+        if p.Kind == llm.ContentThinking && p.Thinking != nil {
+            thinkingChars += len(p.Thinking.Text)
+        }
+    }
+    if thinkingChars > 0 {
+        estimated := thinkingChars / 4
+        if estimated < 1 {
+            estimated = 1
+        }
+        resp.Usage.ReasoningTokens = &estimated
+    }
+}
+```
+
+Apply the same logic to streaming usage: in the `[DONE]` handler, after building the `Usage`, check for `completion_tokens_details.reasoning_tokens` in `chunk.Usage`, and if not present, estimate from `reasoningBuf`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run "TestComplete_ReasoningTokens" -v ./llm/providers/openaicompat/`
+Expected: PASS
+
+- [ ] **Step 5: Refactor and verify**
+
+Run full suite:
+Run: `go test -count=1 ./llm/providers/openaicompat/`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning add llm/providers/openaicompat/adapter.go llm/providers/openaicompat/adapter_test.go
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning commit -m "feat(openaicompat): extract and estimate reasoning_tokens in usage"
+```
+
+---
+
+### Task 5: Add `ProviderQuirks` configuration system
+
+**Files:**
+- Modify: `llm/providers/openaicompat/adapter.go` (new type + NewFromEnv + buildRequestBody)
+- Test: `llm/providers/openaicompat/adapter_test.go`
+
+- [ ] **Step 1: Identify or write the failing test**
+
+Write a test that configures `ProviderQuirks` with `LockTemperature: true` and `LockTopP: true`, sends a request with `Temperature` and `TopP` set, and asserts they are NOT present in the outgoing request body.
+
+```go
+func TestBuildRequestBody_QuirksLockTemperatureAndTopP(t *testing.T) {
+    var gotBody map[string]any
+
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        b, _ := io.ReadAll(r.Body)
+        _ = json.Unmarshal(b, &gotBody)
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{
+  "id": "chatcmpl-q1", "model": "kimi-k2.5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+}`))
+    }))
+    t.Cleanup(srv.Close)
+
+    temp := 0.7
+    topP := 0.9
+    a := &Adapter{
+        APIKey:  "k",
+        BaseURL: srv.URL,
+        Client:  srv.Client(),
+        Quirks: ProviderQuirks{
+            LockTemperature: true,
+            LockTopP:        true,
+        },
+    }
+    _, err := a.Complete(context.Background(), llm.Request{
+        Model:       "kimi-k2.5",
+        Messages:    []llm.Message{llm.User("hi")},
+        Temperature: &temp,
+        TopP:        &topP,
+    })
+    if err != nil {
+        t.Fatalf("Complete: %v", err)
+    }
+    if _, ok := gotBody["temperature"]; ok {
+        t.Fatalf("temperature should be stripped when locked, got %v", gotBody["temperature"])
+    }
+    if _, ok := gotBody["top_p"]; ok {
+        t.Fatalf("top_p should be stripped when locked, got %v", gotBody["top_p"])
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestBuildRequestBody_QuirksLockTemperatureAndTopP -v ./llm/providers/openaicompat/`
+Expected: FAIL — `ProviderQuirks` type doesn't exist, `Adapter` has no `Quirks` field.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Define the `ProviderQuirks` struct and add it to `Adapter`:
+
+```go
+// ProviderQuirks configures per-provider behavioral overrides for OpenAI-compatible
+// APIs that deviate from the standard Chat Completions contract.
+type ProviderQuirks struct {
+    // LockTemperature strips temperature from requests (provider fixes it).
+    LockTemperature bool
+    // LockTopP strips top_p from requests (provider fixes it).
+    LockTopP bool
+    // LockFrequencyPenalty strips frequency_penalty from requests.
+    LockFrequencyPenalty bool
+    // LockPresencePenalty strips presence_penalty from requests.
+    LockPresencePenalty bool
+    // ToolChoiceAutoOnly restricts tool_choice to "auto" or "none" (no "required" or named).
+    ToolChoiceAutoOnly bool
+    // MaxStopSequences limits the number of stop sequences (0 = unlimited).
+    MaxStopSequences int
+    // StripEmptyContent removes message content parts with empty text (e.g., GLM rejects them).
+    StripEmptyContent bool
+    // NoJSONSchema downgrades json_schema response_format to json_object (provider doesn't support it).
+    NoJSONSchema bool
+    // FinishReasonMap maps non-standard finish reasons to canonical values.
+    // E.g., {"sensitive": "content_filter", "network_error": "error"}
+    FinishReasonMap map[string]string
+}
+```
+
+Add to `Adapter`:
+
+```go
+type Adapter struct {
+    APIKey         string
+    BaseURL        string
+    Client         *http.Client
+    DefaultHeaders map[string]string
+    Quirks         ProviderQuirks
+}
+```
+
+Thread `a.Quirks` into `buildRequestBody` by changing the signature:
+
+```go
+func buildRequestBody(req llm.Request, stream bool, quirks ProviderQuirks) (map[string]any, error) {
+```
+
+Apply quirks in `buildRequestBody`:
+
+```go
+// After building the base body, apply quirks.
+if quirks.LockTemperature {
+    delete(body, "temperature")
+}
+if quirks.LockTopP {
+    delete(body, "top_p")
+}
+if quirks.LockFrequencyPenalty {
+    delete(body, "frequency_penalty")
+}
+if quirks.LockPresencePenalty {
+    delete(body, "presence_penalty")
+}
+```
+
+Update all call sites of `buildRequestBody` to pass `a.Quirks`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run TestBuildRequestBody_QuirksLockTemperatureAndTopP -v ./llm/providers/openaicompat/`
+Expected: PASS
+
+- [ ] **Step 5: Refactor and verify**
+
+Run full suite:
+Run: `go test -count=1 ./llm/providers/openaicompat/`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning add llm/providers/openaicompat/adapter.go llm/providers/openaicompat/adapter_test.go
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning commit -m "feat(openaicompat): add ProviderQuirks struct with locked hyperparameter support"
+```
+
+---
+
+### Task 6: Implement remaining quirk behaviors (tool_choice, stop, empty content, json_schema, finish reasons)
+
+**Files:**
+- Modify: `llm/providers/openaicompat/adapter.go` (buildRequestBody, toChatMessages, fromChatCompletionResponse)
+- Test: `llm/providers/openaicompat/adapter_test.go`
+
+- [ ] **Step 1: Identify or write the failing tests**
+
+Write individual tests for each quirk:
+
+```go
+func TestBuildRequestBody_QuirksToolChoiceAutoOnly(t *testing.T) {
+    // When ToolChoiceAutoOnly is true and tool_choice is "required", it should be clamped to "auto".
+    quirks := ProviderQuirks{ToolChoiceAutoOnly: true}
+    req := llm.Request{
+        Model:    "kimi-k2.5",
+        Messages: []llm.Message{llm.User("hi")},
+        Tools:    []llm.ToolDefinition{{Name: "test", Parameters: map[string]any{"type": "object"}}},
+        ToolChoice: &llm.ToolChoice{Mode: "required"},
+    }
+    body, err := buildRequestBody(req, false, quirks)
+    if err != nil {
+        t.Fatalf("buildRequestBody: %v", err)
+    }
+    if body["tool_choice"] != "auto" {
+        t.Fatalf("tool_choice: %v, want auto", body["tool_choice"])
+    }
+}
+
+func TestBuildRequestBody_QuirksMaxStopSequences(t *testing.T) {
+    quirks := ProviderQuirks{MaxStopSequences: 1}
+    req := llm.Request{
+        Model:         "glm-5",
+        Messages:      []llm.Message{llm.User("hi")},
+        StopSequences: []string{"STOP1", "STOP2", "STOP3"},
+    }
+    body, err := buildRequestBody(req, false, quirks)
+    if err != nil {
+        t.Fatalf("buildRequestBody: %v", err)
+    }
+    stops, ok := body["stop"].([]string)
+    if !ok || len(stops) != 1 {
+        t.Fatalf("stop: %v", body["stop"])
+    }
+    if stops[0] != "STOP1" {
+        t.Fatalf("stop[0]: %v, want STOP1", stops[0])
+    }
+}
+
+func TestBuildRequestBody_QuirksNoJSONSchema(t *testing.T) {
+    quirks := ProviderQuirks{NoJSONSchema: true}
+    req := llm.Request{
+        Model:    "glm-5",
+        Messages: []llm.Message{llm.User("hi")},
+        ResponseFormat: &llm.ResponseFormat{
+            Type:       "json_schema",
+            JSONSchema: map[string]any{"type": "object"},
+        },
+    }
+    body, err := buildRequestBody(req, false, quirks)
+    if err != nil {
+        t.Fatalf("buildRequestBody: %v", err)
+    }
+    rf, ok := body["response_format"].(map[string]any)
+    if !ok {
+        t.Fatalf("response_format: %T", body["response_format"])
+    }
+    if rf["type"] != "json_object" {
+        t.Fatalf("response_format.type: %v, want json_object", rf["type"])
+    }
+}
+
+func TestBuildRequestBody_QuirksStripEmptyContent(t *testing.T) {
+    quirks := ProviderQuirks{StripEmptyContent: true}
+    req := llm.Request{
+        Model: "glm-5",
+        Messages: []llm.Message{
+            {Role: llm.RoleUser, Content: []llm.ContentPart{
+                {Kind: llm.ContentText, Text: ""},
+                {Kind: llm.ContentText, Text: "hello"},
+            }},
+        },
+    }
+    body, err := buildRequestBody(req, false, quirks)
+    if err != nil {
+        t.Fatalf("buildRequestBody: %v", err)
+    }
+    msgs, _ := body["messages"].([]map[string]any)
+    // The user message content should be "hello" only (empty part stripped).
+    content, _ := msgs[0]["content"].(string)
+    if content != "hello" {
+        t.Fatalf("content: %q, want 'hello'", content)
+    }
+}
+
+func TestComplete_QuirksFinishReasonMap(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{
+  "id": "chatcmpl-fr1", "model": "glm-5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "filtered"}, "finish_reason": "sensitive"}],
+  "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+}`))
+    }))
+    t.Cleanup(srv.Close)
+
+    a := &Adapter{
+        APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+        Quirks: ProviderQuirks{
+            FinishReasonMap: map[string]string{
+                "sensitive":     "content_filter",
+                "network_error": "error",
+            },
+        },
+    }
+    resp, err := a.Complete(context.Background(), llm.Request{
+        Model:    "glm-5",
+        Messages: []llm.Message{llm.User("hi")},
+    })
+    if err != nil {
+        t.Fatalf("Complete: %v", err)
+    }
+    if resp.Finish.Reason != "content_filter" {
+        t.Fatalf("finish reason: %q, want content_filter", resp.Finish.Reason)
+    }
+    if resp.Finish.Raw != "sensitive" {
+        t.Fatalf("finish raw: %q, want sensitive", resp.Finish.Raw)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -run "TestBuildRequestBody_Quirks|TestComplete_QuirksFinishReasonMap" -v ./llm/providers/openaicompat/`
+Expected: FAIL — quirk behaviors not implemented yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `buildRequestBody`, add after the locked-hyperparameter deletions:
+
+```go
+// tool_choice restriction.
+if quirks.ToolChoiceAutoOnly {
+    if tc, ok := body["tool_choice"]; ok {
+        switch tc {
+        case "auto", "none":
+            // allowed
+        default:
+            body["tool_choice"] = "auto"
+        }
+    }
+}
+
+// Stop sequence limit.
+if quirks.MaxStopSequences > 0 {
+    if stops, ok := body["stop"].([]string); ok && len(stops) > quirks.MaxStopSequences {
+        body["stop"] = stops[:quirks.MaxStopSequences]
+    }
+}
+
+// json_schema downgrade.
+if quirks.NoJSONSchema {
+    if rf, ok := body["response_format"].(map[string]any); ok {
+        if rf["type"] == "json_schema" {
+            body["response_format"] = map[string]any{"type": "json_object"}
+        }
+    }
+}
+```
+
+For `StripEmptyContent`, modify `toChatMessages` to accept quirks and filter empty text parts when `StripEmptyContent` is true. Change `textFromParts` to optionally skip empty texts, or add a post-processing step.
+
+For `FinishReasonMap`, modify `fromChatCompletionResponse` and the streaming `[DONE]` handler to apply the map before `NormalizeFinishReason`. Thread `a.Quirks` through to the response parsing functions. The finish reason mapping logic:
+
+```go
+func (q ProviderQuirks) mapFinishReason(raw string) string {
+    if q.FinishReasonMap == nil {
+        return raw
+    }
+    if mapped, ok := q.FinishReasonMap[raw]; ok {
+        return mapped
+    }
+    return raw
+}
+```
+
+Then in `fromChatCompletionResponse` (which needs to accept quirks now):
+
+```go
+finish := llm.NormalizeFinishReason("", quirks.mapFinishReason(choice.FinishReason))
+```
+
+Update function signatures for `fromChatCompletionResponse`, `toChatMessages`, and `buildRequestBody` to accept `ProviderQuirks`, and update all call sites.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -run "TestBuildRequestBody_Quirks|TestComplete_QuirksFinishReasonMap" -v ./llm/providers/openaicompat/`
+Expected: PASS
+
+- [ ] **Step 5: Refactor and verify**
+
+Run full suite:
+Run: `go test -count=1 ./llm/providers/openaicompat/`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning add llm/providers/openaicompat/adapter.go llm/providers/openaicompat/adapter_test.go
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning commit -m "feat(openaicompat): implement tool_choice, stop, empty content, json_schema, and finish reason quirks"
+```
+
+---
+
+### Task 7: Add named quirk presets and env var configuration
+
+**Files:**
+- Modify: `llm/providers/openaicompat/adapter.go` (NewFromEnv, new preset functions)
+- Test: `llm/providers/openaicompat/adapter_test.go`
+
+- [ ] **Step 1: Identify or write the failing test**
+
+Write tests that verify preset construction and env var parsing:
+
+```go
+func TestQuirksPreset_KimiK2_5(t *testing.T) {
+    q := QuirksPreset("kimi-k2.5")
+    if !q.LockTemperature {
+        t.Error("LockTemperature should be true")
+    }
+    if !q.LockTopP {
+        t.Error("LockTopP should be true")
+    }
+    if !q.LockFrequencyPenalty {
+        t.Error("LockFrequencyPenalty should be true")
+    }
+    if !q.LockPresencePenalty {
+        t.Error("LockPresencePenalty should be true")
+    }
+    if !q.ToolChoiceAutoOnly {
+        t.Error("ToolChoiceAutoOnly should be true")
+    }
+    if !q.NoJSONSchema {
+        t.Error("NoJSONSchema should be true")
+    }
+}
+
+func TestQuirksPreset_GLM5(t *testing.T) {
+    q := QuirksPreset("glm-5")
+    if !q.StripEmptyContent {
+        t.Error("StripEmptyContent should be true")
+    }
+    if !q.ToolChoiceAutoOnly {
+        t.Error("ToolChoiceAutoOnly should be true")
+    }
+    if q.MaxStopSequences != 1 {
+        t.Errorf("MaxStopSequences: %d, want 1", q.MaxStopSequences)
+    }
+    if !q.NoJSONSchema {
+        t.Error("NoJSONSchema should be true")
+    }
+    if q.FinishReasonMap["sensitive"] != "content_filter" {
+        t.Errorf("FinishReasonMap[sensitive]: %v", q.FinishReasonMap["sensitive"])
+    }
+    if q.FinishReasonMap["network_error"] != "error" {
+        t.Errorf("FinishReasonMap[network_error]: %v", q.FinishReasonMap["network_error"])
+    }
+}
+
+func TestQuirksPreset_Unknown_ReturnsEmpty(t *testing.T) {
+    q := QuirksPreset("unknown-provider")
+    if q.LockTemperature || q.StripEmptyContent || q.ToolChoiceAutoOnly {
+        t.Error("unknown preset should return zero-value quirks")
+    }
+}
+
+func TestNewFromEnv_ParsesQuirksEnvVar(t *testing.T) {
+    t.Setenv("OPENAI_COMPATIBLE_BASE_URL", "http://example.com")
+    t.Setenv("OPENAI_COMPATIBLE_API_KEY", "test-key")
+    t.Setenv("OPENAI_COMPATIBLE_PROVIDER_QUIRKS", "kimi-k2.5")
+
+    a, err := NewFromEnv()
+    if err != nil {
+        t.Fatalf("NewFromEnv: %v", err)
+    }
+    if !a.Quirks.LockTemperature {
+        t.Error("expected LockTemperature from kimi-k2.5 preset")
+    }
+    if !a.Quirks.ToolChoiceAutoOnly {
+        t.Error("expected ToolChoiceAutoOnly from kimi-k2.5 preset")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -run "TestQuirksPreset|TestNewFromEnv_ParsesQuirksEnvVar" -v ./llm/providers/openaicompat/`
+Expected: FAIL — `QuirksPreset` function doesn't exist, `NewFromEnv` doesn't read the env var.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// QuirksPreset returns a ProviderQuirks configuration for a known provider name.
+// Unknown names return zero-value quirks (no restrictions).
+func QuirksPreset(name string) ProviderQuirks {
+    switch strings.ToLower(strings.TrimSpace(name)) {
+    case "kimi-k2.5", "kimi", "moonshot":
+        return ProviderQuirks{
+            LockTemperature:      true,
+            LockTopP:             true,
+            LockFrequencyPenalty: true,
+            LockPresencePenalty:  true,
+            ToolChoiceAutoOnly:   true, // When thinking is enabled
+            NoJSONSchema:         true,
+        }
+    case "glm-5", "glm-5-turbo", "glm", "zhipu":
+        return ProviderQuirks{
+            StripEmptyContent:  true,
+            ToolChoiceAutoOnly: true,
+            MaxStopSequences:   1,
+            NoJSONSchema:       true,
+            FinishReasonMap: map[string]string{
+                "sensitive":     "content_filter",
+                "network_error": "error",
+            },
+        }
+    default:
+        return ProviderQuirks{}
+    }
+}
+```
+
+Update `NewFromEnv`:
+
+```go
+func NewFromEnv() (*Adapter, error) {
+    base := strings.TrimSpace(os.Getenv("OPENAI_COMPATIBLE_BASE_URL"))
+    if base == "" {
+        return nil, fmt.Errorf("OPENAI_COMPATIBLE_BASE_URL is required")
+    }
+    key := strings.TrimSpace(os.Getenv("OPENAI_COMPATIBLE_API_KEY"))
+
+    var quirks ProviderQuirks
+    if preset := strings.TrimSpace(os.Getenv("OPENAI_COMPATIBLE_PROVIDER_QUIRKS")); preset != "" {
+        quirks = QuirksPreset(preset)
+    }
+
+    return &Adapter{
+        APIKey:  key,
+        BaseURL: strings.TrimRight(base, "/"),
+        Client:  &http.Client{Timeout: 0},
+        Quirks:  quirks,
+    }, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -run "TestQuirksPreset|TestNewFromEnv_ParsesQuirksEnvVar" -v ./llm/providers/openaicompat/`
+Expected: PASS
+
+- [ ] **Step 5: Refactor and verify**
+
+Run full suite and `go vet`:
+Run: `go test -count=1 ./llm/providers/openaicompat/ && go vet ./llm/providers/openaicompat/`
+Expected: all PASS, no vet issues
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning add llm/providers/openaicompat/adapter.go llm/providers/openaicompat/adapter_test.go
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning commit -m "feat(openaicompat): add QuirksPreset for kimi-k2.5 and glm-5, with env var config"
+```
+
+---
+
+### Task 8: Streaming finish reason quirk mapping and streaming reasoning in final response
+
+**Files:**
+- Modify: `llm/providers/openaicompat/adapter.go` (Stream goroutine's [DONE] handler and finish_reason tracking)
+- Test: `llm/providers/openaicompat/adapter_test.go`
+
+- [ ] **Step 1: Identify or write the failing test**
+
+Write a streaming test where the finish_reason is `"sensitive"` and the adapter has the GLM quirk preset. Assert the FINISH event has `content_filter` as the reason.
+
+```go
+func TestStream_QuirksFinishReasonMap(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "text/event-stream")
+        flusher, _ := w.(http.Flusher)
+        chunks := []string{
+            `{"id":"chatcmpl-1","model":"glm-5","choices":[{"index":0,"delta":{"role":"assistant","content":"filtered"},"finish_reason":null}]}`,
+            `{"id":"chatcmpl-1","model":"glm-5","choices":[{"index":0,"delta":{},"finish_reason":"sensitive"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}`,
+        }
+        for _, c := range chunks {
+            fmt.Fprintf(w, "data: %s\n\n", c)
+            flusher.Flush()
+        }
+        fmt.Fprintf(w, "data: [DONE]\n\n")
+        flusher.Flush()
+    }))
+    t.Cleanup(srv.Close)
+
+    a := &Adapter{
+        APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+        Quirks: QuirksPreset("glm-5"),
+    }
+    st, err := a.Stream(context.Background(), llm.Request{
+        Model:    "glm-5",
+        Messages: []llm.Message{llm.User("hi")},
+    })
+    if err != nil {
+        t.Fatalf("Stream: %v", err)
+    }
+    defer st.Close()
+
+    var finishReason string
+    for ev := range st.Events() {
+        if ev.Type == llm.StreamEventFinish && ev.FinishReason != nil {
+            finishReason = ev.FinishReason.Reason
+        }
+    }
+    if finishReason != "content_filter" {
+        t.Fatalf("finish reason: %q, want content_filter", finishReason)
+    }
+}
+```
+
+Also write a streaming test that verifies the final response from FINISH contains `ContentThinking` when reasoning was streamed:
+
+```go
+func TestStream_ReasoningContent_InFinalResponse(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "text/event-stream")
+        flusher, _ := w.(http.Flusher)
+        chunks := []string{
+            `{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"thinking..."},"finish_reason":null}]}`,
+            `{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":null}]}`,
+            `{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":10,"total_tokens":15}}`,
+        }
+        for _, c := range chunks {
+            fmt.Fprintf(w, "data: %s\n\n", c)
+            flusher.Flush()
+        }
+        fmt.Fprintf(w, "data: [DONE]\n\n")
+        flusher.Flush()
+    }))
+    t.Cleanup(srv.Close)
+
+    a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+    st, err := a.Stream(context.Background(), llm.Request{
+        Model:    "kimi-k2.5",
+        Messages: []llm.Message{llm.User("think")},
+    })
+    if err != nil {
+        t.Fatalf("Stream: %v", err)
+    }
+    defer st.Close()
+
+    var finalResp *llm.Response
+    for ev := range st.Events() {
+        if ev.Type == llm.StreamEventFinish && ev.Response != nil {
+            finalResp = ev.Response
+        }
+    }
+    if finalResp == nil {
+        t.Fatal("no FINISH response")
+    }
+    if finalResp.ReasoningText() != "thinking..." {
+        t.Fatalf("ReasoningText(): %q", finalResp.ReasoningText())
+    }
+    if finalResp.Text() != "answer" {
+        t.Fatalf("Text(): %q", finalResp.Text())
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -run "TestStream_QuirksFinishReasonMap|TestStream_ReasoningContent_InFinalResponse" -v ./llm/providers/openaicompat/`
+Expected: FAIL — streaming doesn't apply quirk finish reason mapping, and the final response doesn't include thinking content.
+
+- [ ] **Step 3: Write minimal implementation**
+
+The Stream goroutine needs access to `a.Quirks`. It is already a method on `*Adapter`, so `a.Quirks` is directly accessible.
+
+In the streaming goroutine's `[DONE]` handler, apply the quirk mapping to `finishReason`:
+
+```go
+// Apply quirk finish reason mapping.
+finishReason = a.Quirks.mapFinishReason(finishReason)
+```
+
+The reasoning content in the final response should already work from Task 2's implementation (the `[DONE]` handler builds the message with `reasoningBuf`). If it doesn't because Task 2's implementation isn't quite complete, fix it here.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -run "TestStream_QuirksFinishReasonMap|TestStream_ReasoningContent_InFinalResponse" -v ./llm/providers/openaicompat/`
+Expected: PASS
+
+- [ ] **Step 5: Refactor and verify**
+
+Run full suite:
+Run: `go test -count=1 ./llm/providers/openaicompat/`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning add llm/providers/openaicompat/adapter.go llm/providers/openaicompat/adapter_test.go
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning commit -m "feat(openaicompat): apply quirk finish reason mapping in streaming and verify reasoning in final response"
+```
+
+---
+
+### Task 9: Full integration test with Kimi K2.5 and GLM 5.0 mock scenarios
+
+**Files:**
+- Test: `llm/providers/openaicompat/adapter_test.go`
+
+- [ ] **Step 1: Write comprehensive integration tests**
+
+Write two end-to-end style tests using httptest that simulate realistic Kimi K2.5 and GLM 5.0 conversations including reasoning, tool calls, and quirk behaviors.
+
+```go
+func TestIntegration_KimiK2_5_ReasoningWithToolCall(t *testing.T) {
+    // Simulates: user asks question -> model thinks -> model calls tool -> user provides result -> model thinks -> model answers.
+    // Verifies: reasoning_content parsed, tool calls work, reasoning round-tripped in follow-up, locked params stripped.
+    requestCount := 0
+    var firstReqBody, secondReqBody map[string]any
+
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        requestCount++
+        b, _ := io.ReadAll(r.Body)
+        w.Header().Set("Content-Type", "application/json")
+
+        if requestCount == 1 {
+            _ = json.Unmarshal(b, &firstReqBody)
+            // First response: thinking + tool call.
+            _, _ = w.Write([]byte(`{
+  "id": "chatcmpl-k1", "model": "kimi-k2.5",
+  "choices": [{"index": 0, "message": {
+    "role": "assistant",
+    "reasoning_content": "I need to check the weather API.",
+    "content": null,
+    "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{\"city\":\"SF\"}"}}]
+  }, "finish_reason": "tool_calls"}],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 30, "total_tokens": 40, "completion_tokens_details": {"reasoning_tokens": 20}}
+}`))
+        } else {
+            _ = json.Unmarshal(b, &secondReqBody)
+            // Second response: thinking + final answer.
+            _, _ = w.Write([]byte(`{
+  "id": "chatcmpl-k2", "model": "kimi-k2.5",
+  "choices": [{"index": 0, "message": {
+    "role": "assistant",
+    "reasoning_content": "The weather data says sunny and 72F.",
+    "content": "It's sunny and 72F in San Francisco!"
+  }, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 50, "completion_tokens": 40, "total_tokens": 90}
+}`))
+        }
+    }))
+    t.Cleanup(srv.Close)
+
+    temp := 0.7
+    a := &Adapter{
+        APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+        Quirks: QuirksPreset("kimi-k2.5"),
+    }
+
+    // First request: user asks, model thinks and calls tool.
+    resp1, err := a.Complete(context.Background(), llm.Request{
+        Model:       "kimi-k2.5",
+        Messages:    []llm.Message{llm.User("What's the weather in SF?")},
+        Tools:       []llm.ToolDefinition{{Name: "get_weather", Parameters: map[string]any{"type": "object"}}},
+        Temperature: &temp,
+    })
+    if err != nil {
+        t.Fatalf("first Complete: %v", err)
+    }
+
+    // Verify temperature was stripped.
+    if _, ok := firstReqBody["temperature"]; ok {
+        t.Error("temperature should be stripped for kimi-k2.5")
+    }
+
+    // Verify reasoning was parsed.
+    if resp1.ReasoningText() != "I need to check the weather API." {
+        t.Fatalf("first reasoning: %q", resp1.ReasoningText())
+    }
+    // Verify native reasoning tokens.
+    if resp1.Usage.ReasoningTokens == nil || *resp1.Usage.ReasoningTokens != 20 {
+        t.Fatalf("first reasoning tokens: %v", resp1.Usage.ReasoningTokens)
+    }
+
+    // Second request: include previous assistant message (with thinking) and tool result.
+    resp2, err := a.Complete(context.Background(), llm.Request{
+        Model: "kimi-k2.5",
+        Messages: []llm.Message{
+            llm.User("What's the weather in SF?"),
+            resp1.Message, // Should include ContentThinking + ContentToolCall
+            llm.ToolResultNamed("call_1", "get_weather", "Sunny, 72F", false),
+        },
+    })
+    if err != nil {
+        t.Fatalf("second Complete: %v", err)
+    }
+
+    // Verify reasoning_content was round-tripped in the second request's assistant message.
+    msgs, _ := secondReqBody["messages"].([]any)
+    assistantMsg, _ := msgs[1].(map[string]any)
+    if rc, _ := assistantMsg["reasoning_content"].(string); rc != "I need to check the weather API." {
+        t.Fatalf("round-tripped reasoning_content: %q", rc)
+    }
+
+    // Verify second response.
+    if resp2.ReasoningText() != "The weather data says sunny and 72F." {
+        t.Fatalf("second reasoning: %q", resp2.ReasoningText())
+    }
+    if resp2.Text() != "It's sunny and 72F in San Francisco!" {
+        t.Fatalf("second text: %q", resp2.Text())
+    }
+    // Verify estimated reasoning tokens (no native count in second response).
+    if resp2.Usage.ReasoningTokens == nil {
+        t.Fatal("second reasoning tokens should be estimated")
+    }
+}
+
+func TestIntegration_GLM5_EmptyContentAndSensitiveFilter(t *testing.T) {
+    var gotBody map[string]any
+
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        b, _ := io.ReadAll(r.Body)
+        _ = json.Unmarshal(b, &gotBody)
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{
+  "id": "chatcmpl-g1", "model": "glm-5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "I cannot answer that."}, "finish_reason": "sensitive"}],
+  "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10}
+}`))
+    }))
+    t.Cleanup(srv.Close)
+
+    a := &Adapter{
+        APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+        Quirks: QuirksPreset("glm-5"),
+    }
+
+    resp, err := a.Complete(context.Background(), llm.Request{
+        Model: "glm-5",
+        Messages: []llm.Message{
+            {Role: llm.RoleUser, Content: []llm.ContentPart{
+                {Kind: llm.ContentText, Text: ""},
+                {Kind: llm.ContentText, Text: "tell me something"},
+            }},
+        },
+        StopSequences: []string{"STOP1", "STOP2", "STOP3"},
+    })
+    if err != nil {
+        t.Fatalf("Complete: %v", err)
+    }
+
+    // Verify stop sequences truncated to 1.
+    stops, _ := gotBody["stop"].([]any)
+    if len(stops) != 1 {
+        t.Fatalf("stop sequences: %v, want 1 element", stops)
+    }
+
+    // Verify finish reason mapped.
+    if resp.Finish.Reason != "content_filter" {
+        t.Fatalf("finish reason: %q, want content_filter", resp.Finish.Reason)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `go test -run "TestIntegration_KimiK2_5|TestIntegration_GLM5" -v ./llm/providers/openaicompat/`
+Expected: PASS (all previous tasks have implemented the required functionality)
+
+- [ ] **Step 3: Run the complete test suite**
+
+Run: `go test -count=1 -v ./llm/providers/openaicompat/`
+Expected: All tests PASS including the 12 original tests (regression baseline).
+
+- [ ] **Step 4: Run full project tests**
+
+Run: `go test -short -count=1 ./...`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning add llm/providers/openaicompat/adapter_test.go
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning commit -m "test(openaicompat): add integration tests for kimi-k2.5 and glm-5 scenarios"
+```
+
+---
+
+### Task 10: Build verification and final cleanup
+
+**Files:**
+- Verify: all files in `llm/providers/openaicompat/`
+
+- [ ] **Step 1: Build the project**
+
+Run: `cd /home/user/code/serf/.worktrees/openaicompat-reasoning && make build`
+Expected: successful build with no errors
+
+- [ ] **Step 2: Run vet and full tests**
+
+Run: `cd /home/user/code/serf/.worktrees/openaicompat-reasoning && go vet ./... && go test -count=1 ./...`
+Expected: no vet issues, all tests pass
+
+- [ ] **Step 3: Review for code quality**
+
+Verify:
+- No `TODO` or `FIXME` comments left behind
+- All exported types and functions have doc comments
+- `ProviderQuirks`, `QuirksPreset`, and all quirk fields are documented
+- No unnecessary imports
+- Code follows existing patterns (e.g., `llm.IntFromAny` usage, error handling style)
+
+- [ ] **Step 4: Final commit if any cleanup was needed**
+
+```bash
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning add llm/providers/openaicompat/adapter.go llm/providers/openaicompat/adapter_test.go
+git -C /home/user/code/serf/.worktrees/openaicompat-reasoning commit -m "chore(openaicompat): final cleanup and documentation"
+```

--- a/docs/plans/2026-03-23-openaicompat-reasoning.md
+++ b/docs/plans/2026-03-23-openaicompat-reasoning.md
@@ -325,6 +325,22 @@ if choice.Delta.Content != "" {
         Delta:  choice.Delta.Content,
     })
 }
+
+// Tool call deltas — also close reasoning before the first tool call if needed.
+// (Kimi K2.5 can emit reasoning_content followed by tool_calls with no text in between.)
+```
+
+In the existing tool call delta block, add at the top (before creating new tool call state):
+
+```go
+if !exists {
+    // Close reasoning before the first tool call, matching Anthropic's event ordering.
+    if reasoningStarted && !textStarted {
+        s.Send(llm.StreamEvent{Type: llm.StreamEventReasoningEnd})
+        reasoningStarted = false // Prevent double-close in [DONE].
+    }
+    // ... existing tool call start logic ...
+}
 ```
 
 In the `[DONE]` handler, add reasoning content to the final response message and close reasoning if still open:
@@ -944,7 +960,7 @@ if quirks.NoJSONSchema {
 
 For `StripEmptyContent`, modify `toChatMessages` to accept quirks and filter empty text parts when `StripEmptyContent` is true. Change `textFromParts` to optionally skip empty texts, or add a post-processing step.
 
-For `FinishReasonMap`, modify `fromChatCompletionResponse` and the streaming `[DONE]` handler to apply the map before `NormalizeFinishReason`. Thread `a.Quirks` through to the response parsing functions. The finish reason mapping logic:
+For `FinishReasonMap`, modify `fromChatCompletionResponse` and the streaming `[DONE]` handler to apply the map while preserving the original raw value. Thread `a.Quirks` through to the response parsing functions. The finish reason mapping logic:
 
 ```go
 func (q ProviderQuirks) mapFinishReason(raw string) string {
@@ -961,8 +977,22 @@ func (q ProviderQuirks) mapFinishReason(raw string) string {
 Then in `fromChatCompletionResponse` (which needs to accept quirks now):
 
 ```go
-finish := llm.NormalizeFinishReason("", quirks.mapFinishReason(choice.FinishReason))
+// Map the provider-specific finish reason to a canonical value,
+// but preserve the original provider value in .Raw for diagnostics.
+rawFinish := choice.FinishReason
+mappedFinish := quirks.mapFinishReason(rawFinish)
+var finish llm.FinishReason
+if mappedFinish == rawFinish {
+    // No quirk mapping applied — use standard normalization.
+    finish = llm.NormalizeFinishReason("", rawFinish)
+} else {
+    // Quirk mapping applied — use the mapped value as the canonical reason,
+    // but keep the original provider value in .Raw.
+    finish = llm.FinishReason{Reason: mappedFinish, Raw: rawFinish}
+}
 ```
+
+**Important:** `NormalizeFinishReason("", mapped)` would set `.Raw = mapped`, losing the original provider value (e.g., `"sensitive"`). The explicit construction above preserves it so diagnostics and tests can see the original finish reason.
 
 Update function signatures for `fromChatCompletionResponse`, `toChatMessages`, and `buildRequestBody` to accept `ProviderQuirks`, and update all call sites.
 
@@ -1259,12 +1289,21 @@ Expected: FAIL — streaming doesn't apply quirk finish reason mapping, and the 
 
 The Stream goroutine needs access to `a.Quirks`. It is already a method on `*Adapter`, so `a.Quirks` is directly accessible.
 
-In the streaming goroutine's `[DONE]` handler, apply the quirk mapping to `finishReason`:
+In the streaming goroutine's `[DONE]` handler, apply the quirk mapping to `finishReason` while preserving the original raw value, using the same pattern as the non-streaming fix in Task 6:
 
 ```go
-// Apply quirk finish reason mapping.
-finishReason = a.Quirks.mapFinishReason(finishReason)
+// Apply quirk finish reason mapping, preserving the original raw value.
+rawFinish := finishReason
+mappedFinish := a.Quirks.mapFinishReason(rawFinish)
+var finish llm.FinishReason
+if mappedFinish == rawFinish {
+    finish = llm.NormalizeFinishReason("", rawFinish)
+} else {
+    finish = llm.FinishReason{Reason: mappedFinish, Raw: rawFinish}
+}
 ```
+
+Replace the existing `finish := llm.NormalizeFinishReason("", finishReason)` with the above block.
 
 The reasoning content in the final response should already work from Task 2's implementation (the `[DONE]` handler builds the message with `reasoningBuf`). If it doesn't because Task 2's implementation isn't quite complete, fix it here.
 

--- a/llm/providers/openaicompat/adapter.go
+++ b/llm/providers/openaicompat/adapter.go
@@ -165,7 +165,7 @@ func (a *Adapter) Complete(ctx context.Context, req llm.Request) (llm.Response, 
 		return llm.Response{}, llm.ErrorFromHTTPStatus("openai-compatible", statusCode, msg, raw, retryAfter)
 	}
 
-	resp, err := fromChatCompletionResponse(raw)
+	resp, err := fromChatCompletionResponse(raw, a.Quirks)
 	if err != nil {
 		return resp, err
 	}
@@ -432,7 +432,7 @@ func buildRequestBody(req llm.Request, stream bool, quirks ProviderQuirks) (map[
 		"model": req.Model,
 	}
 
-	msgs, err := toChatMessages(req.Messages)
+	msgs, err := toChatMessages(req.Messages, quirks)
 	if err != nil {
 		return nil, err
 	}
@@ -496,38 +496,72 @@ func buildRequestBody(req llm.Request, stream bool, quirks ProviderQuirks) (map[
 	if quirks.LockPresencePenalty {
 		delete(body, "presence_penalty")
 	}
+	if quirks.ToolChoiceAutoOnly {
+		if tc, ok := body["tool_choice"]; ok {
+			switch tc {
+			case "auto", "none":
+				// allowed
+			default:
+				body["tool_choice"] = "auto"
+			}
+		}
+	}
+	if quirks.MaxStopSequences > 0 {
+		if stops, ok := body["stop"].([]string); ok && len(stops) > quirks.MaxStopSequences {
+			body["stop"] = stops[:quirks.MaxStopSequences]
+		}
+	}
+	if quirks.NoJSONSchema {
+		if rf, ok := body["response_format"].(map[string]any); ok {
+			if rf["type"] == "json_schema" {
+				body["response_format"] = map[string]any{"type": "json_object"}
+			}
+		}
+	}
 
 	return body, nil
 }
 
-func toChatMessages(messages []llm.Message) ([]map[string]any, error) {
+func toChatMessages(messages []llm.Message, quirks ProviderQuirks) ([]map[string]any, error) {
 	out := make([]map[string]any, 0, len(messages))
 	for _, m := range messages {
+		// Strip empty text parts when the quirk is enabled.
+		content := m.Content
+		if quirks.StripEmptyContent {
+			filtered := make([]llm.ContentPart, 0, len(content))
+			for _, p := range content {
+				if p.Kind == llm.ContentText && p.Text == "" {
+					continue
+				}
+				filtered = append(filtered, p)
+			}
+			content = filtered
+		}
 		switch m.Role {
 		case llm.RoleSystem, llm.RoleDeveloper:
 			out = append(out, map[string]any{
 				"role":    "system",
-				"content": textFromParts(m.Content),
+				"content": textFromParts(content),
 			})
 		case llm.RoleUser:
-			if hasImageContent(m.Content) {
+			if hasImageContent(content) {
 				out = append(out, map[string]any{
 					"role":    "user",
-					"content": buildMultimodalParts(m.Content),
+					"content": buildMultimodalParts(content),
 				})
 			} else {
 				out = append(out, map[string]any{
 					"role":    "user",
-					"content": textFromParts(m.Content),
+					"content": textFromParts(content),
 				})
 			}
 		case llm.RoleAssistant:
 			msg := map[string]any{
 				"role": "assistant",
 			}
-			text := textFromParts(m.Content)
-			calls := toolCallsFromParts(m.Content)
-			reasoning := thinkingFromParts(m.Content)
+			text := textFromParts(content)
+			calls := toolCallsFromParts(content)
+			reasoning := thinkingFromParts(content)
 			if reasoning != "" {
 				msg["reasoning_content"] = reasoning
 			}
@@ -541,20 +575,20 @@ func toChatMessages(messages []llm.Message) ([]map[string]any, error) {
 			}
 			out = append(out, msg)
 		case llm.RoleTool:
-			for _, p := range m.Content {
+			for _, p := range content {
 				if p.Kind == llm.ContentToolResult && p.ToolResult != nil {
-					content := ""
+					resultContent := ""
 					switch v := p.ToolResult.Content.(type) {
 					case string:
-						content = v
+						resultContent = v
 					default:
 						b, _ := json.Marshal(v)
-						content = string(b)
+						resultContent = string(b)
 					}
 					out = append(out, map[string]any{
 						"role":         "tool",
 						"tool_call_id": p.ToolResult.ToolCallID,
-						"content":      content,
+						"content":      resultContent,
 					})
 				}
 			}
@@ -773,7 +807,7 @@ type chatChunkToolCall struct {
 	Function chatFunctionCall `json:"function"`
 }
 
-func fromChatCompletionResponse(raw map[string]any) (llm.Response, error) {
+func fromChatCompletionResponse(raw map[string]any, quirks ProviderQuirks) (llm.Response, error) {
 	b, err := json.Marshal(raw)
 	if err != nil {
 		return llm.Response{}, err
@@ -812,7 +846,16 @@ func fromChatCompletionResponse(raw map[string]any) (llm.Response, error) {
 	}
 
 	msg := llm.Message{Role: llm.RoleAssistant, Content: parts}
-	finish := llm.NormalizeFinishReason("", choice.FinishReason)
+
+	// Map the provider-specific finish reason using quirks, preserving the original in .Raw.
+	rawFinish := choice.FinishReason
+	mappedFinish := quirks.mapFinishReason(rawFinish)
+	var finish llm.FinishReason
+	if mappedFinish == rawFinish {
+		finish = llm.NormalizeFinishReason("", rawFinish)
+	} else {
+		finish = llm.FinishReason{Reason: mappedFinish, Raw: rawFinish}
+	}
 
 	resp := llm.Response{
 		Provider: "openai-compatible",

--- a/llm/providers/openaicompat/adapter.go
+++ b/llm/providers/openaicompat/adapter.go
@@ -107,6 +107,9 @@ func init() {
 	})
 }
 
+// NewFromEnv creates an Adapter configured from environment variables.
+// Required: OPENAI_COMPATIBLE_BASE_URL. Optional: OPENAI_COMPATIBLE_API_KEY,
+// OPENAI_COMPATIBLE_PROVIDER_QUIRKS (a named preset like "kimi-k2.5" or "glm-5").
 func NewFromEnv() (*Adapter, error) {
 	base := strings.TrimSpace(os.Getenv("OPENAI_COMPATIBLE_BASE_URL"))
 	if base == "" {

--- a/llm/providers/openaicompat/adapter.go
+++ b/llm/providers/openaicompat/adapter.go
@@ -332,7 +332,15 @@ func (a *Adapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, erro
 						ToolCall: &completedToolCalls[i],
 					})
 				}
-				finish := llm.NormalizeFinishReason("", finishReason)
+				// Apply quirk finish reason mapping, preserving the original raw value.
+				rawFinish := finishReason
+				mappedFinish := a.Quirks.mapFinishReason(rawFinish)
+				var finish llm.FinishReason
+				if mappedFinish == rawFinish {
+					finish = llm.NormalizeFinishReason("", rawFinish)
+				} else {
+					finish = llm.FinishReason{Reason: mappedFinish, Raw: rawFinish}
+				}
 				finalResp := &llm.Response{
 					Provider:  "openai-compatible",
 					Model:     model,
@@ -342,6 +350,17 @@ func (a *Adapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, erro
 				}
 				if usage != nil {
 					finalResp.Usage = *usage
+				}
+				// Estimate reasoning tokens from reasoning buffer when not natively reported.
+				if finalResp.Usage.ReasoningTokens == nil && reasoningBuf.Len() > 0 {
+					estimated := reasoningBuf.Len() / 4
+					if estimated < 1 {
+						estimated = 1
+					}
+					finalResp.Usage.ReasoningTokens = &estimated
+					if usage != nil {
+						usage.ReasoningTokens = &estimated
+					}
 				}
 				s.Send(llm.StreamEvent{
 					Type:         llm.StreamEventFinish,
@@ -368,6 +387,12 @@ func (a *Adapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, erro
 				u.TotalTokens = u.InputTokens + u.OutputTokens
 				if v := llm.IntFromAny(chunk.Usage["total_tokens"]); v > 0 {
 					u.TotalTokens = v
+				}
+				// Extract native reasoning tokens from completion_tokens_details.
+				if details, ok := chunk.Usage["completion_tokens_details"].(map[string]any); ok {
+					if rt := llm.IntFromAny(details["reasoning_tokens"]); rt > 0 {
+						u.ReasoningTokens = &rt
+					}
 				}
 				usage = &u
 			}

--- a/llm/providers/openaicompat/adapter.go
+++ b/llm/providers/openaicompat/adapter.go
@@ -19,11 +19,49 @@ import (
 	"primeradiant.com/serf/llm"
 )
 
+// ProviderQuirks configures per-provider behavioral overrides for OpenAI-compatible
+// APIs that deviate from the standard Chat Completions contract.
+type ProviderQuirks struct {
+	// LockTemperature strips temperature from requests (provider fixes it).
+	LockTemperature bool
+	// LockTopP strips top_p from requests (provider fixes it).
+	LockTopP bool
+	// LockFrequencyPenalty strips frequency_penalty from requests.
+	LockFrequencyPenalty bool
+	// LockPresencePenalty strips presence_penalty from requests.
+	LockPresencePenalty bool
+	// ToolChoiceAutoOnly restricts tool_choice to "auto" or "none" (no "required" or named).
+	ToolChoiceAutoOnly bool
+	// MaxStopSequences limits the number of stop sequences (0 = unlimited).
+	MaxStopSequences int
+	// StripEmptyContent removes message content parts with empty text.
+	StripEmptyContent bool
+	// NoJSONSchema downgrades json_schema response_format to json_object.
+	NoJSONSchema bool
+	// FinishReasonMap maps non-standard finish reasons to canonical values.
+	// E.g., {"sensitive": "content_filter", "network_error": "error"}
+	FinishReasonMap map[string]string
+}
+
+// mapFinishReason translates a provider-specific finish reason using the quirk map.
+// If no mapping exists, returns the original value unchanged.
+func (q ProviderQuirks) mapFinishReason(raw string) string {
+	if q.FinishReasonMap == nil {
+		return raw
+	}
+	if mapped, ok := q.FinishReasonMap[raw]; ok {
+		return mapped
+	}
+	return raw
+}
+
+// Adapter implements llm.ProviderAdapter for OpenAI-compatible services.
 type Adapter struct {
 	APIKey         string
 	BaseURL        string
 	Client         *http.Client
 	DefaultHeaders map[string]string
+	Quirks         ProviderQuirks
 }
 
 func init() {
@@ -109,7 +147,7 @@ func (a *Adapter) Complete(ctx context.Context, req llm.Request) (llm.Response, 
 		a.Client = &http.Client{Timeout: 0}
 	}
 
-	body, err := buildRequestBody(req, false)
+	body, err := buildRequestBody(req, false, a.Quirks)
 	if err != nil {
 		return llm.Response{}, err
 	}
@@ -143,7 +181,7 @@ func (a *Adapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, erro
 	ctx, timeoutCancel := llm.ApplyAdapterTimeout(ctx, req.AdapterTimeout, true)
 	defer timeoutCancel()
 
-	body, err := buildRequestBody(req, true)
+	body, err := buildRequestBody(req, true, a.Quirks)
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +427,7 @@ func (a *Adapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, erro
 
 // --- Request building ---
 
-func buildRequestBody(req llm.Request, stream bool) (map[string]any, error) {
+func buildRequestBody(req llm.Request, stream bool, quirks ProviderQuirks) (map[string]any, error) {
 	body := map[string]any{
 		"model": req.Model,
 	}
@@ -443,6 +481,20 @@ func buildRequestBody(req llm.Request, stream bool) (map[string]any, error) {
 				body[k] = v
 			}
 		}
+	}
+
+	// Apply provider quirks.
+	if quirks.LockTemperature {
+		delete(body, "temperature")
+	}
+	if quirks.LockTopP {
+		delete(body, "top_p")
+	}
+	if quirks.LockFrequencyPenalty {
+		delete(body, "frequency_penalty")
+	}
+	if quirks.LockPresencePenalty {
+		delete(body, "presence_penalty")
 	}
 
 	return body, nil

--- a/llm/providers/openaicompat/adapter.go
+++ b/llm/providers/openaicompat/adapter.go
@@ -203,6 +203,8 @@ func (a *Adapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, erro
 		toolCalls := map[int]*toolCallState{}
 		var textStarted bool
 		var textBuf strings.Builder
+		var reasoningStarted bool
+		var reasoningBuf strings.Builder
 		var model string
 		var finishReason string
 		var usage *llm.Usage
@@ -212,16 +214,25 @@ func (a *Adapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, erro
 			data := string(ev.Data)
 			if data == "[DONE]" {
 				finished = true
-				// Emit tool call end events for any open tool calls.
+
+				// Close reasoning if still open (e.g., reasoning only, no text or tool calls).
+				if reasoningStarted && !textStarted && len(toolCalls) == 0 {
+					s.Send(llm.StreamEvent{Type: llm.StreamEventReasoningEnd})
+				}
+
+				// Collect tool call data before emitting end events (for final response).
+				var completedToolCalls []llm.ToolCallData
 				for idx, tc := range toolCalls {
+					tcd := llm.ToolCallData{
+						ID:        tc.id,
+						Name:      tc.name,
+						Arguments: json.RawMessage(tc.args.String()),
+						Type:      "function",
+					}
+					completedToolCalls = append(completedToolCalls, tcd)
 					s.Send(llm.StreamEvent{
-						Type: llm.StreamEventToolCallEnd,
-						ToolCall: &llm.ToolCallData{
-							ID:        tc.id,
-							Name:      tc.name,
-							Arguments: json.RawMessage(tc.args.String()),
-							Type:      "function",
-						},
+						Type:     llm.StreamEventToolCallEnd,
+						ToolCall: &tcd,
 					})
 					delete(toolCalls, idx)
 				}
@@ -232,8 +243,20 @@ func (a *Adapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, erro
 
 				// Build final response.
 				msg := llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{}}
+				if reasoningBuf.Len() > 0 {
+					msg.Content = append(msg.Content, llm.ContentPart{
+						Kind:     llm.ContentThinking,
+						Thinking: &llm.ThinkingData{Text: reasoningBuf.String()},
+					})
+				}
 				if textBuf.Len() > 0 {
 					msg.Content = append(msg.Content, llm.ContentPart{Kind: llm.ContentText, Text: textBuf.String()})
+				}
+				for i := range completedToolCalls {
+					msg.Content = append(msg.Content, llm.ContentPart{
+						Kind:     llm.ContentToolCall,
+						ToolCall: &completedToolCalls[i],
+					})
 				}
 				finish := llm.NormalizeFinishReason("", finishReason)
 				finalResp := &llm.Response{
@@ -284,8 +307,24 @@ func (a *Adapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, erro
 				finishReason = choice.FinishReason
 			}
 
-			// Text delta.
+			// Reasoning content delta.
+			if choice.Delta.ReasoningContent != "" {
+				if !reasoningStarted {
+					s.Send(llm.StreamEvent{Type: llm.StreamEventReasoningStart})
+					reasoningStarted = true
+				}
+				reasoningBuf.WriteString(choice.Delta.ReasoningContent)
+				s.Send(llm.StreamEvent{
+					Type:           llm.StreamEventReasoningDelta,
+					ReasoningDelta: choice.Delta.ReasoningContent,
+				})
+			}
+
+			// Text delta — close reasoning first if transitioning from reasoning to text.
 			if choice.Delta.Content != "" {
+				if reasoningStarted && !textStarted {
+					s.Send(llm.StreamEvent{Type: llm.StreamEventReasoningEnd})
+				}
 				if !textStarted {
 					s.Send(llm.StreamEvent{Type: llm.StreamEventTextStart, TextID: "text_0"})
 					textStarted = true
@@ -302,6 +341,11 @@ func (a *Adapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, erro
 			for _, tc := range choice.Delta.ToolCalls {
 				state, exists := toolCalls[tc.Index]
 				if !exists {
+					// Close reasoning before the first tool call if needed.
+					if reasoningStarted && !textStarted {
+						s.Send(llm.StreamEvent{Type: llm.StreamEventReasoningEnd})
+						reasoningStarted = false // Prevent double-close in [DONE].
+					}
 					state = &toolCallState{
 						id:   tc.ID,
 						name: tc.Function.Name,
@@ -646,9 +690,10 @@ type chatChunkChoice struct {
 }
 
 type chatDelta struct {
-	Role      string              `json:"role"`
-	Content   string              `json:"content"`
-	ToolCalls []chatChunkToolCall `json:"tool_calls,omitempty"`
+	Role             string              `json:"role"`
+	Content          string              `json:"content"`
+	ReasoningContent string              `json:"reasoning_content,omitempty"`
+	ToolCalls        []chatChunkToolCall `json:"tool_calls,omitempty"`
 }
 
 type chatChunkToolCall struct {

--- a/llm/providers/openaicompat/adapter.go
+++ b/llm/providers/openaicompat/adapter.go
@@ -781,6 +781,30 @@ func fromChatCompletionResponse(raw map[string]any) (llm.Response, error) {
 		if v := llm.IntFromAny(parsed.Usage["total_tokens"]); v > 0 {
 			resp.Usage.TotalTokens = v
 		}
+
+		// Extract native reasoning tokens from completion_tokens_details.
+		if details, ok := parsed.Usage["completion_tokens_details"].(map[string]any); ok {
+			if rt := llm.IntFromAny(details["reasoning_tokens"]); rt > 0 {
+				resp.Usage.ReasoningTokens = &rt
+			}
+		}
+	}
+
+	// Estimate reasoning tokens from thinking content when not natively reported.
+	if resp.Usage.ReasoningTokens == nil {
+		var thinkingChars int
+		for _, p := range parts {
+			if p.Kind == llm.ContentThinking && p.Thinking != nil {
+				thinkingChars += len(p.Thinking.Text)
+			}
+		}
+		if thinkingChars > 0 {
+			estimated := thinkingChars / 4
+			if estimated < 1 {
+				estimated = 1
+			}
+			resp.Usage.ReasoningTokens = &estimated
+		}
 	}
 
 	return resp, nil

--- a/llm/providers/openaicompat/adapter.go
+++ b/llm/providers/openaicompat/adapter.go
@@ -615,9 +615,10 @@ type chatChoice struct {
 }
 
 type chatMessage struct {
-	Role      string         `json:"role"`
-	Content   string         `json:"content"`
-	ToolCalls []chatToolCall `json:"tool_calls,omitempty"`
+	Role             string         `json:"role"`
+	Content          string         `json:"content"`
+	ReasoningContent string         `json:"reasoning_content,omitempty"`
+	ToolCalls        []chatToolCall `json:"tool_calls,omitempty"`
 }
 
 type chatToolCall struct {
@@ -674,6 +675,12 @@ func fromChatCompletionResponse(raw map[string]any) (llm.Response, error) {
 
 	// Build message.
 	parts := []llm.ContentPart{}
+	if choice.Message.ReasoningContent != "" {
+		parts = append(parts, llm.ContentPart{
+			Kind:     llm.ContentThinking,
+			Thinking: &llm.ThinkingData{Text: choice.Message.ReasoningContent},
+		})
+	}
 	if choice.Message.Content != "" {
 		parts = append(parts, llm.ContentPart{Kind: llm.ContentText, Text: choice.Message.Content})
 	}

--- a/llm/providers/openaicompat/adapter.go
+++ b/llm/providers/openaicompat/adapter.go
@@ -475,6 +475,10 @@ func toChatMessages(messages []llm.Message) ([]map[string]any, error) {
 			}
 			text := textFromParts(m.Content)
 			calls := toolCallsFromParts(m.Content)
+			reasoning := thinkingFromParts(m.Content)
+			if reasoning != "" {
+				msg["reasoning_content"] = reasoning
+			}
 			if len(calls) > 0 {
 				msg["tool_calls"] = calls
 				if text != "" {
@@ -515,6 +519,20 @@ func textFromParts(parts []llm.ContentPart) string {
 				b.WriteString("\n")
 			}
 			b.WriteString(p.Text)
+		}
+	}
+	return b.String()
+}
+
+// thinkingFromParts concatenates all ContentThinking parts' text.
+func thinkingFromParts(parts []llm.ContentPart) string {
+	var b strings.Builder
+	for _, p := range parts {
+		if p.Kind == llm.ContentThinking && p.Thinking != nil && p.Thinking.Text != "" {
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(p.Thinking.Text)
 		}
 	}
 	return b.String()

--- a/llm/providers/openaicompat/adapter.go
+++ b/llm/providers/openaicompat/adapter.go
@@ -55,6 +55,35 @@ func (q ProviderQuirks) mapFinishReason(raw string) string {
 	return raw
 }
 
+// QuirksPreset returns a ProviderQuirks configuration for a known provider name.
+// Unknown names return zero-value quirks (no restrictions).
+func QuirksPreset(name string) ProviderQuirks {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "kimi-k2.5", "kimi", "moonshot":
+		return ProviderQuirks{
+			LockTemperature:      true,
+			LockTopP:             true,
+			LockFrequencyPenalty: true,
+			LockPresencePenalty:  true,
+			ToolChoiceAutoOnly:   true,
+			NoJSONSchema:         true,
+		}
+	case "glm-5", "glm-5-turbo", "glm", "zhipu":
+		return ProviderQuirks{
+			StripEmptyContent:  true,
+			ToolChoiceAutoOnly: true,
+			MaxStopSequences:   1,
+			NoJSONSchema:       true,
+			FinishReasonMap: map[string]string{
+				"sensitive":     "content_filter",
+				"network_error": "error",
+			},
+		}
+	default:
+		return ProviderQuirks{}
+	}
+}
+
 // Adapter implements llm.ProviderAdapter for OpenAI-compatible services.
 type Adapter struct {
 	APIKey         string
@@ -84,10 +113,17 @@ func NewFromEnv() (*Adapter, error) {
 		return nil, fmt.Errorf("OPENAI_COMPATIBLE_BASE_URL is required")
 	}
 	key := strings.TrimSpace(os.Getenv("OPENAI_COMPATIBLE_API_KEY"))
+
+	var quirks ProviderQuirks
+	if preset := strings.TrimSpace(os.Getenv("OPENAI_COMPATIBLE_PROVIDER_QUIRKS")); preset != "" {
+		quirks = QuirksPreset(preset)
+	}
+
 	return &Adapter{
 		APIKey:  key,
 		BaseURL: strings.TrimRight(base, "/"),
 		Client:  &http.Client{Timeout: 0},
+		Quirks:  quirks,
 	}, nil
 }
 

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -1051,3 +1051,175 @@ func TestComplete_NoReasoningContent_OnlyText(t *testing.T) {
 		t.Fatalf("ReasoningText() should be empty, got %q", resp.ReasoningText())
 	}
 }
+
+func TestStream_ReasoningContent_EmitsReasoningEvents(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+
+		chunks := []string{
+			`{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Let me "},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"reasoning_content":"think..."},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"content":"The answer"},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"content":" is 42."},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":20,"total_tokens":25}}`,
+		}
+		for _, c := range chunks {
+			fmt.Fprintf(w, "data: %s\n\n", c)
+			flusher.Flush()
+		}
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	st, err := a.Stream(ctx, llm.Request{
+		Model:    "kimi-k2.5",
+		Messages: []llm.Message{llm.User("What is the meaning of life?")},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer st.Close()
+
+	var kinds []llm.StreamEventType
+	var reasoningDeltas []string
+	var textDeltas []string
+	var finalResp *llm.Response
+	for ev := range st.Events() {
+		kinds = append(kinds, ev.Type)
+		if ev.Type == llm.StreamEventReasoningDelta {
+			reasoningDeltas = append(reasoningDeltas, ev.ReasoningDelta)
+		}
+		if ev.Type == llm.StreamEventTextDelta {
+			textDeltas = append(textDeltas, ev.Delta)
+		}
+		if ev.Type == llm.StreamEventFinish && ev.Response != nil {
+			finalResp = ev.Response
+		}
+	}
+
+	if strings.Join(reasoningDeltas, "") != "Let me think..." {
+		t.Fatalf("reasoning deltas: %q", strings.Join(reasoningDeltas, ""))
+	}
+	if strings.Join(textDeltas, "") != "The answer is 42." {
+		t.Fatalf("text deltas: %q", strings.Join(textDeltas, ""))
+	}
+
+	// Verify event ordering.
+	var reasoningStartIdx, reasoningEndIdx, textStartIdx int
+	for i, k := range kinds {
+		switch k {
+		case llm.StreamEventReasoningStart:
+			reasoningStartIdx = i
+		case llm.StreamEventReasoningEnd:
+			reasoningEndIdx = i
+		case llm.StreamEventTextStart:
+			textStartIdx = i
+		}
+	}
+	if reasoningStartIdx >= reasoningEndIdx {
+		t.Fatalf("REASONING_START (%d) should come before REASONING_END (%d)", reasoningStartIdx, reasoningEndIdx)
+	}
+	if reasoningEndIdx >= textStartIdx {
+		t.Fatalf("REASONING_END (%d) should come before TEXT_START (%d)", reasoningEndIdx, textStartIdx)
+	}
+
+	// Verify final response includes thinking content.
+	if finalResp == nil {
+		t.Fatal("no FINISH response")
+	}
+	if finalResp.ReasoningText() != "Let me think..." {
+		t.Fatalf("final ReasoningText(): %q", finalResp.ReasoningText())
+	}
+	if finalResp.Text() != "The answer is 42." {
+		t.Fatalf("final Text(): %q", finalResp.Text())
+	}
+}
+
+func TestStream_ReasoningContent_ThenToolCall_EmitsReasoningEndBeforeToolStart(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+
+		chunks := []string{
+			`{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"I need to call the API."},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":\"SF\"}"}}]},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":10,"total_tokens":15}}`,
+		}
+		for _, c := range chunks {
+			fmt.Fprintf(w, "data: %s\n\n", c)
+			flusher.Flush()
+		}
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	st, err := a.Stream(ctx, llm.Request{
+		Model:    "kimi-k2.5",
+		Messages: []llm.Message{llm.User("weather in SF?")},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer st.Close()
+
+	var kinds []llm.StreamEventType
+	var finalResp *llm.Response
+	for ev := range st.Events() {
+		kinds = append(kinds, ev.Type)
+		if ev.Type == llm.StreamEventFinish && ev.Response != nil {
+			finalResp = ev.Response
+		}
+	}
+
+	// REASONING_END should appear before TOOL_CALL_START.
+	var reasoningEndIdx, toolCallStartIdx int
+	reasoningEndIdx = -1
+	toolCallStartIdx = -1
+	for i, k := range kinds {
+		if k == llm.StreamEventReasoningEnd {
+			reasoningEndIdx = i
+		}
+		if k == llm.StreamEventToolCallStart && toolCallStartIdx == -1 {
+			toolCallStartIdx = i
+		}
+	}
+	if reasoningEndIdx == -1 {
+		t.Fatalf("expected REASONING_END event, kinds: %v", kinds)
+	}
+	if toolCallStartIdx == -1 {
+		t.Fatalf("expected TOOL_CALL_START event, kinds: %v", kinds)
+	}
+	if reasoningEndIdx >= toolCallStartIdx {
+		t.Fatalf("REASONING_END (%d) should come before TOOL_CALL_START (%d)", reasoningEndIdx, toolCallStartIdx)
+	}
+
+	// No TEXT_START or TEXT_DELTA events.
+	for _, k := range kinds {
+		if k == llm.StreamEventTextStart || k == llm.StreamEventTextDelta {
+			t.Fatalf("unexpected text event: %v", k)
+		}
+	}
+
+	// Final response should have ContentThinking + ContentToolCall (no ContentText).
+	if finalResp == nil {
+		t.Fatal("no FINISH response")
+	}
+	if finalResp.ReasoningText() != "I need to call the API." {
+		t.Fatalf("ReasoningText(): %q", finalResp.ReasoningText())
+	}
+	if len(finalResp.ToolCalls()) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(finalResp.ToolCalls()))
+	}
+}

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -1789,3 +1789,166 @@ func TestStream_ReasoningContent_InFinalResponse(t *testing.T) {
 		t.Fatalf("Text(): %q", finalResp.Text())
 	}
 }
+
+// --- Integration tests ---
+
+func TestIntegration_KimiK2_5_ReasoningWithToolCall(t *testing.T) {
+	requestCount := 0
+	var firstReqBody, secondReqBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		b, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+
+		if requestCount == 1 {
+			_ = json.Unmarshal(b, &firstReqBody)
+			_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-k1", "model": "kimi-k2.5",
+  "choices": [{"index": 0, "message": {
+    "role": "assistant",
+    "reasoning_content": "I need to check the weather API.",
+    "content": null,
+    "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{\"city\":\"SF\"}"}}]
+  }, "finish_reason": "tool_calls"}],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 30, "total_tokens": 40, "completion_tokens_details": {"reasoning_tokens": 20}}
+}`))
+		} else {
+			_ = json.Unmarshal(b, &secondReqBody)
+			_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-k2", "model": "kimi-k2.5",
+  "choices": [{"index": 0, "message": {
+    "role": "assistant",
+    "reasoning_content": "The weather data says sunny and 72F.",
+    "content": "It's sunny and 72F in San Francisco!"
+  }, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 50, "completion_tokens": 40, "total_tokens": 90}
+}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	temp := 0.7
+	a := &Adapter{
+		APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+		Quirks: QuirksPreset("kimi-k2.5"),
+	}
+
+	// First request: user asks, model thinks and calls tool.
+	resp1, err := a.Complete(context.Background(), llm.Request{
+		Model:       "kimi-k2.5",
+		Messages:    []llm.Message{llm.User("What's the weather in SF?")},
+		Tools:       []llm.ToolDefinition{{Name: "get_weather", Parameters: map[string]any{"type": "object"}}},
+		Temperature: &temp,
+	})
+	if err != nil {
+		t.Fatalf("first Complete: %v", err)
+	}
+
+	// Verify temperature was stripped.
+	if _, ok := firstReqBody["temperature"]; ok {
+		t.Error("temperature should be stripped for kimi-k2.5")
+	}
+
+	// Verify reasoning was parsed.
+	if resp1.ReasoningText() != "I need to check the weather API." {
+		t.Fatalf("first reasoning: %q", resp1.ReasoningText())
+	}
+	// Verify native reasoning tokens.
+	if resp1.Usage.ReasoningTokens == nil || *resp1.Usage.ReasoningTokens != 20 {
+		t.Fatalf("first reasoning tokens: %v", resp1.Usage.ReasoningTokens)
+	}
+	// Verify tool call.
+	if len(resp1.ToolCalls()) != 1 || resp1.ToolCalls()[0].Name != "get_weather" {
+		t.Fatalf("first tool calls: %v", resp1.ToolCalls())
+	}
+
+	// Second request: include previous assistant message (with thinking) and tool result.
+	resp2, err := a.Complete(context.Background(), llm.Request{
+		Model: "kimi-k2.5",
+		Messages: []llm.Message{
+			llm.User("What's the weather in SF?"),
+			resp1.Message, // Should include ContentThinking + ContentToolCall
+			llm.ToolResultNamed("call_1", "get_weather", "Sunny, 72F", false),
+		},
+	})
+	if err != nil {
+		t.Fatalf("second Complete: %v", err)
+	}
+
+	// Verify reasoning_content was round-tripped in the second request's assistant message.
+	msgs, _ := secondReqBody["messages"].([]any)
+	assistantMsg, _ := msgs[1].(map[string]any)
+	if rc, _ := assistantMsg["reasoning_content"].(string); rc != "I need to check the weather API." {
+		t.Fatalf("round-tripped reasoning_content: %q", rc)
+	}
+
+	// Verify second response.
+	if resp2.ReasoningText() != "The weather data says sunny and 72F." {
+		t.Fatalf("second reasoning: %q", resp2.ReasoningText())
+	}
+	if resp2.Text() != "It's sunny and 72F in San Francisco!" {
+		t.Fatalf("second text: %q", resp2.Text())
+	}
+	// Verify estimated reasoning tokens (no native count in second response).
+	if resp2.Usage.ReasoningTokens == nil {
+		t.Fatal("second reasoning tokens should be estimated")
+	}
+}
+
+func TestIntegration_GLM5_EmptyContentAndSensitiveFilter(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-g1", "model": "glm-5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "I cannot answer that."}, "finish_reason": "sensitive"}],
+  "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{
+		APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+		Quirks: QuirksPreset("glm-5"),
+	}
+
+	resp, err := a.Complete(context.Background(), llm.Request{
+		Model: "glm-5",
+		Messages: []llm.Message{
+			{Role: llm.RoleUser, Content: []llm.ContentPart{
+				{Kind: llm.ContentText, Text: ""},
+				{Kind: llm.ContentText, Text: "tell me something"},
+			}},
+		},
+		StopSequences: []string{"STOP1", "STOP2", "STOP3"},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	// Verify stop sequences truncated to 1.
+	stops, _ := gotBody["stop"].([]any)
+	if len(stops) != 1 {
+		t.Fatalf("stop sequences: %v, want 1 element", stops)
+	}
+
+	// Verify user message content (empty part stripped).
+	msgs, _ := gotBody["messages"].([]any)
+	userMsg, _ := msgs[0].(map[string]any)
+	content, _ := userMsg["content"].(string)
+	if content != "tell me something" {
+		t.Fatalf("content: %q, want 'tell me something'", content)
+	}
+
+	// Verify finish reason mapped.
+	if resp.Finish.Reason != "content_filter" {
+		t.Fatalf("finish reason: %q, want content_filter", resp.Finish.Reason)
+	}
+	if resp.Finish.Raw != "sensitive" {
+		t.Fatalf("finish raw: %q, want sensitive", resp.Finish.Raw)
+	}
+}

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -1620,3 +1620,79 @@ func TestComplete_QuirksFinishReasonMap(t *testing.T) {
 		t.Fatalf("finish raw: %q, want sensitive", resp.Finish.Raw)
 	}
 }
+
+// --- Quirk presets and env var tests ---
+
+func TestQuirksPreset_KimiK2_5(t *testing.T) {
+	q := QuirksPreset("kimi-k2.5")
+	if !q.LockTemperature {
+		t.Error("LockTemperature should be true")
+	}
+	if !q.LockTopP {
+		t.Error("LockTopP should be true")
+	}
+	if !q.LockFrequencyPenalty {
+		t.Error("LockFrequencyPenalty should be true")
+	}
+	if !q.LockPresencePenalty {
+		t.Error("LockPresencePenalty should be true")
+	}
+	if !q.ToolChoiceAutoOnly {
+		t.Error("ToolChoiceAutoOnly should be true")
+	}
+	if !q.NoJSONSchema {
+		t.Error("NoJSONSchema should be true")
+	}
+}
+
+func TestQuirksPreset_GLM5(t *testing.T) {
+	q := QuirksPreset("glm-5")
+	if !q.StripEmptyContent {
+		t.Error("StripEmptyContent should be true")
+	}
+	if !q.ToolChoiceAutoOnly {
+		t.Error("ToolChoiceAutoOnly should be true")
+	}
+	if q.MaxStopSequences != 1 {
+		t.Errorf("MaxStopSequences: %d, want 1", q.MaxStopSequences)
+	}
+	if !q.NoJSONSchema {
+		t.Error("NoJSONSchema should be true")
+	}
+	if q.FinishReasonMap["sensitive"] != "content_filter" {
+		t.Errorf("FinishReasonMap[sensitive]: %v", q.FinishReasonMap["sensitive"])
+	}
+	if q.FinishReasonMap["network_error"] != "error" {
+		t.Errorf("FinishReasonMap[network_error]: %v", q.FinishReasonMap["network_error"])
+	}
+}
+
+func TestQuirksPreset_Unknown_ReturnsEmpty(t *testing.T) {
+	q := QuirksPreset("unknown-provider")
+	if q.LockTemperature || q.StripEmptyContent || q.ToolChoiceAutoOnly {
+		t.Error("unknown preset should return zero-value quirks")
+	}
+	if q.MaxStopSequences != 0 {
+		t.Errorf("MaxStopSequences: %d, want 0", q.MaxStopSequences)
+	}
+	if q.FinishReasonMap != nil {
+		t.Errorf("FinishReasonMap should be nil, got %v", q.FinishReasonMap)
+	}
+}
+
+func TestNewFromEnv_ParsesQuirksEnvVar(t *testing.T) {
+	t.Setenv("OPENAI_COMPATIBLE_BASE_URL", "http://example.com")
+	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "test-key")
+	t.Setenv("OPENAI_COMPATIBLE_PROVIDER_QUIRKS", "kimi-k2.5")
+
+	a, err := NewFromEnv()
+	if err != nil {
+		t.Fatalf("NewFromEnv: %v", err)
+	}
+	if !a.Quirks.LockTemperature {
+		t.Error("expected LockTemperature from kimi-k2.5 preset")
+	}
+	if !a.Quirks.ToolChoiceAutoOnly {
+		t.Error("expected ToolChoiceAutoOnly from kimi-k2.5 preset")
+	}
+}

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -1306,3 +1306,54 @@ func TestComplete_NoThinking_OmitsReasoningContent(t *testing.T) {
 		t.Fatalf("reasoning_content should be absent, got %v", assistantMsg["reasoning_content"])
 	}
 }
+
+func TestComplete_ReasoningTokens_NativeFromUsage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-u1",
+  "model": "kimi-k2.5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "reasoning_content": "thinking...", "content": "done"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 50, "total_tokens": 60, "completion_tokens_details": {"reasoning_tokens": 35}}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+	resp, err := a.Complete(context.Background(), llm.Request{
+		Model:    "kimi-k2.5",
+		Messages: []llm.Message{llm.User("think")},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Usage.ReasoningTokens == nil || *resp.Usage.ReasoningTokens != 35 {
+		t.Fatalf("ReasoningTokens: %v, want 35", resp.Usage.ReasoningTokens)
+	}
+}
+
+func TestComplete_ReasoningTokens_EstimatedFromContent(t *testing.T) {
+	reasoning := strings.Repeat("abcd", 20) // 80 chars -> 80/4 = 20 estimated tokens
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+  "id": "chatcmpl-u2",
+  "model": "glm-5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "reasoning_content": %q, "content": "done"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 50, "total_tokens": 60}
+}`, reasoning)
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+	resp, err := a.Complete(context.Background(), llm.Request{
+		Model:    "glm-5",
+		Messages: []llm.Message{llm.User("think")},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Usage.ReasoningTokens == nil || *resp.Usage.ReasoningTokens != 20 {
+		t.Fatalf("ReasoningTokens: %v, want 20", resp.Usage.ReasoningTokens)
+	}
+}

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -969,3 +969,85 @@ func TestAdapter_Complete_Metadata_Propagated(t *testing.T) {
 		t.Errorf("metadata[user_id] = %v, want %q", md["user_id"], "u123")
 	}
 }
+
+// --- Reasoning content tests ---
+
+func TestComplete_ReasoningContent_ParsedAsThinking(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-rc1",
+  "model": "kimi-k2.5",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "reasoning_content": "Let me think step by step...\nFirst, I need to consider...",
+      "content": "The answer is 42."
+    },
+    "finish_reason": "stop"
+  }],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 50, "total_tokens": 60}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+	resp, err := a.Complete(context.Background(), llm.Request{
+		Model:    "kimi-k2.5",
+		Messages: []llm.Message{llm.User("What is the meaning of life?")},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	if len(resp.Message.Content) < 2 {
+		t.Fatalf("expected at least 2 content parts, got %d: %+v", len(resp.Message.Content), resp.Message.Content)
+	}
+	if resp.Message.Content[0].Kind != llm.ContentThinking {
+		t.Fatalf("first part kind: %v, want thinking", resp.Message.Content[0].Kind)
+	}
+	if resp.Message.Content[0].Thinking == nil || resp.Message.Content[0].Thinking.Text != "Let me think step by step...\nFirst, I need to consider..." {
+		t.Fatalf("thinking text: %+v", resp.Message.Content[0].Thinking)
+	}
+	if resp.Message.Content[1].Kind != llm.ContentText {
+		t.Fatalf("second part kind: %v, want text", resp.Message.Content[1].Kind)
+	}
+	if resp.Message.Content[1].Text != "The answer is 42." {
+		t.Fatalf("text: %q", resp.Message.Content[1].Text)
+	}
+	if resp.ReasoningText() != "Let me think step by step...\nFirst, I need to consider..." {
+		t.Fatalf("ReasoningText(): %q", resp.ReasoningText())
+	}
+}
+
+func TestComplete_NoReasoningContent_OnlyText(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-nr1",
+  "model": "gpt-4o",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hello"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+	resp, err := a.Complete(context.Background(), llm.Request{
+		Model:    "gpt-4o",
+		Messages: []llm.Message{llm.User("hi")},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(resp.Message.Content) != 1 {
+		t.Fatalf("expected 1 content part, got %d", len(resp.Message.Content))
+	}
+	if resp.Message.Content[0].Kind != llm.ContentText {
+		t.Fatalf("part kind: %v, want text", resp.Message.Content[0].Kind)
+	}
+	if resp.ReasoningText() != "" {
+		t.Fatalf("ReasoningText() should be empty, got %q", resp.ReasoningText())
+	}
+}

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -1696,3 +1696,96 @@ func TestNewFromEnv_ParsesQuirksEnvVar(t *testing.T) {
 		t.Error("expected ToolChoiceAutoOnly from kimi-k2.5 preset")
 	}
 }
+
+// --- Streaming quirks tests ---
+
+func TestStream_QuirksFinishReasonMap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		chunks := []string{
+			`{"id":"chatcmpl-1","model":"glm-5","choices":[{"index":0,"delta":{"role":"assistant","content":"filtered"},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-1","model":"glm-5","choices":[{"index":0,"delta":{},"finish_reason":"sensitive"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}`,
+		}
+		for _, c := range chunks {
+			fmt.Fprintf(w, "data: %s\n\n", c)
+			flusher.Flush()
+		}
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{
+		APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+		Quirks: QuirksPreset("glm-5"),
+	}
+	st, err := a.Stream(context.Background(), llm.Request{
+		Model:    "glm-5",
+		Messages: []llm.Message{llm.User("hi")},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer st.Close()
+
+	var finishReason string
+	var finishRaw string
+	for ev := range st.Events() {
+		if ev.Type == llm.StreamEventFinish && ev.FinishReason != nil {
+			finishReason = ev.FinishReason.Reason
+			finishRaw = ev.FinishReason.Raw
+		}
+	}
+	if finishReason != "content_filter" {
+		t.Fatalf("finish reason: %q, want content_filter", finishReason)
+	}
+	if finishRaw != "sensitive" {
+		t.Fatalf("finish raw: %q, want sensitive", finishRaw)
+	}
+}
+
+func TestStream_ReasoningContent_InFinalResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		chunks := []string{
+			`{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"thinking..."},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-1","model":"kimi-k2.5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":10,"total_tokens":15}}`,
+		}
+		for _, c := range chunks {
+			fmt.Fprintf(w, "data: %s\n\n", c)
+			flusher.Flush()
+		}
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+	st, err := a.Stream(context.Background(), llm.Request{
+		Model:    "kimi-k2.5",
+		Messages: []llm.Message{llm.User("think")},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer st.Close()
+
+	var finalResp *llm.Response
+	for ev := range st.Events() {
+		if ev.Type == llm.StreamEventFinish && ev.Response != nil {
+			finalResp = ev.Response
+		}
+	}
+	if finalResp == nil {
+		t.Fatal("no FINISH response")
+	}
+	if finalResp.ReasoningText() != "thinking..." {
+		t.Fatalf("ReasoningText(): %q", finalResp.ReasoningText())
+	}
+	if finalResp.Text() != "answer" {
+		t.Fatalf("Text(): %q", finalResp.Text())
+	}
+}

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -1402,3 +1402,221 @@ func TestBuildRequestBody_QuirksLockTemperatureAndTopP(t *testing.T) {
 		t.Fatalf("top_p should be stripped when locked, got %v", gotBody["top_p"])
 	}
 }
+
+func TestBuildRequestBody_QuirksToolChoiceAutoOnly(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-q2", "model": "kimi-k2.5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{
+		APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+		Quirks: ProviderQuirks{ToolChoiceAutoOnly: true},
+	}
+	_, err := a.Complete(context.Background(), llm.Request{
+		Model:      "kimi-k2.5",
+		Messages:   []llm.Message{llm.User("hi")},
+		Tools:      []llm.ToolDefinition{{Name: "test", Parameters: map[string]any{"type": "object"}}},
+		ToolChoice: &llm.ToolChoice{Mode: "required"},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if gotBody["tool_choice"] != "auto" {
+		t.Fatalf("tool_choice: %v, want auto", gotBody["tool_choice"])
+	}
+}
+
+func TestBuildRequestBody_QuirksToolChoiceAutoOnly_PreservesAutoAndNone(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-q3", "model": "kimi-k2.5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{
+		APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+		Quirks: ProviderQuirks{ToolChoiceAutoOnly: true},
+	}
+	_, err := a.Complete(context.Background(), llm.Request{
+		Model:      "kimi-k2.5",
+		Messages:   []llm.Message{llm.User("hi")},
+		Tools:      []llm.ToolDefinition{{Name: "test", Parameters: map[string]any{"type": "object"}}},
+		ToolChoice: &llm.ToolChoice{Mode: "auto"},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if gotBody["tool_choice"] != "auto" {
+		t.Fatalf("tool_choice: %v, want auto (unchanged)", gotBody["tool_choice"])
+	}
+}
+
+func TestBuildRequestBody_QuirksMaxStopSequences(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-q4", "model": "glm-5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{
+		APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+		Quirks: ProviderQuirks{MaxStopSequences: 1},
+	}
+	_, err := a.Complete(context.Background(), llm.Request{
+		Model:         "glm-5",
+		Messages:      []llm.Message{llm.User("hi")},
+		StopSequences: []string{"STOP1", "STOP2", "STOP3"},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	stops, ok := gotBody["stop"].([]any)
+	if !ok || len(stops) != 1 {
+		t.Fatalf("stop: %v (type %T)", gotBody["stop"], gotBody["stop"])
+	}
+	if stops[0] != "STOP1" {
+		t.Fatalf("stop[0]: %v, want STOP1", stops[0])
+	}
+}
+
+func TestBuildRequestBody_QuirksNoJSONSchema(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-q5", "model": "glm-5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{
+		APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+		Quirks: ProviderQuirks{NoJSONSchema: true},
+	}
+	_, err := a.Complete(context.Background(), llm.Request{
+		Model:    "glm-5",
+		Messages: []llm.Message{llm.User("hi")},
+		ResponseFormat: &llm.ResponseFormat{
+			Type:       "json_schema",
+			JSONSchema: map[string]any{"type": "object"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	rf, ok := gotBody["response_format"].(map[string]any)
+	if !ok {
+		t.Fatalf("response_format: %T", gotBody["response_format"])
+	}
+	if rf["type"] != "json_object" {
+		t.Fatalf("response_format.type: %v, want json_object", rf["type"])
+	}
+	if _, hasSchema := rf["json_schema"]; hasSchema {
+		t.Fatalf("json_schema should be removed from response_format")
+	}
+}
+
+func TestBuildRequestBody_QuirksStripEmptyContent(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-q6", "model": "glm-5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{
+		APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+		Quirks: ProviderQuirks{StripEmptyContent: true},
+	}
+	_, err := a.Complete(context.Background(), llm.Request{
+		Model: "glm-5",
+		Messages: []llm.Message{
+			{Role: llm.RoleUser, Content: []llm.ContentPart{
+				{Kind: llm.ContentText, Text: ""},
+				{Kind: llm.ContentText, Text: "hello"},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	msgs, _ := gotBody["messages"].([]any)
+	userMsg, _ := msgs[0].(map[string]any)
+	content, _ := userMsg["content"].(string)
+	if content != "hello" {
+		t.Fatalf("content: %q, want 'hello'", content)
+	}
+}
+
+func TestComplete_QuirksFinishReasonMap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-fr1", "model": "glm-5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "filtered"}, "finish_reason": "sensitive"}],
+  "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{
+		APIKey: "k", BaseURL: srv.URL, Client: srv.Client(),
+		Quirks: ProviderQuirks{
+			FinishReasonMap: map[string]string{
+				"sensitive":     "content_filter",
+				"network_error": "error",
+			},
+		},
+	}
+	resp, err := a.Complete(context.Background(), llm.Request{
+		Model:    "glm-5",
+		Messages: []llm.Message{llm.User("hi")},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Finish.Reason != "content_filter" {
+		t.Fatalf("finish reason: %q, want content_filter", resp.Finish.Reason)
+	}
+	if resp.Finish.Raw != "sensitive" {
+		t.Fatalf("finish raw: %q, want sensitive", resp.Finish.Raw)
+	}
+}

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -1357,3 +1357,48 @@ func TestComplete_ReasoningTokens_EstimatedFromContent(t *testing.T) {
 		t.Fatalf("ReasoningTokens: %v, want 20", resp.Usage.ReasoningTokens)
 	}
 }
+
+// --- Provider quirks tests ---
+
+func TestBuildRequestBody_QuirksLockTemperatureAndTopP(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-q1", "model": "kimi-k2.5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	temp := 0.7
+	topP := 0.9
+	a := &Adapter{
+		APIKey:  "k",
+		BaseURL: srv.URL,
+		Client:  srv.Client(),
+		Quirks: ProviderQuirks{
+			LockTemperature: true,
+			LockTopP:        true,
+		},
+	}
+	_, err := a.Complete(context.Background(), llm.Request{
+		Model:       "kimi-k2.5",
+		Messages:    []llm.Message{llm.User("hi")},
+		Temperature: &temp,
+		TopP:        &topP,
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if _, ok := gotBody["temperature"]; ok {
+		t.Fatalf("temperature should be stripped when locked, got %v", gotBody["temperature"])
+	}
+	if _, ok := gotBody["top_p"]; ok {
+		t.Fatalf("top_p should be stripped when locked, got %v", gotBody["top_p"])
+	}
+}

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -1223,3 +1223,86 @@ func TestStream_ReasoningContent_ThenToolCall_EmitsReasoningEndBeforeToolStart(t
 		t.Fatalf("expected 1 tool call, got %d", len(finalResp.ToolCalls()))
 	}
 }
+
+func TestComplete_ThinkingContentRoundTripped_AsReasoningContent(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-rt1",
+  "model": "kimi-k2.5",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "OK"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+	_, err := a.Complete(context.Background(), llm.Request{
+		Model: "kimi-k2.5",
+		Messages: []llm.Message{
+			llm.User("What is 2+2?"),
+			{Role: llm.RoleAssistant, Content: []llm.ContentPart{
+				{Kind: llm.ContentThinking, Thinking: &llm.ThinkingData{Text: "I need to add 2 and 2."}},
+				{Kind: llm.ContentText, Text: "The answer is 4."},
+			}},
+			llm.User("Are you sure?"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	msgs, _ := gotBody["messages"].([]any)
+	if len(msgs) != 3 {
+		t.Fatalf("messages count: %d", len(msgs))
+	}
+	assistantMsg, _ := msgs[1].(map[string]any)
+	rc, ok := assistantMsg["reasoning_content"].(string)
+	if !ok || rc != "I need to add 2 and 2." {
+		t.Fatalf("reasoning_content: %v (ok=%v)", assistantMsg["reasoning_content"], ok)
+	}
+	content, _ := assistantMsg["content"].(string)
+	if content != "The answer is 4." {
+		t.Fatalf("content: %v", assistantMsg["content"])
+	}
+}
+
+func TestComplete_NoThinking_OmitsReasoningContent(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "chatcmpl-nr2",
+  "model": "gpt-4o",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "OK"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+	_, err := a.Complete(context.Background(), llm.Request{
+		Model: "gpt-4o",
+		Messages: []llm.Message{
+			llm.User("hi"),
+			llm.Assistant("hey"),
+			llm.User("what?"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	msgs, _ := gotBody["messages"].([]any)
+	assistantMsg, _ := msgs[1].(map[string]any)
+	if _, ok := assistantMsg["reasoning_content"]; ok {
+		t.Fatalf("reasoning_content should be absent, got %v", assistantMsg["reasoning_content"])
+	}
+}


### PR DESCRIPTION
## Summary
- Parse `reasoning_content` in non-streaming and streaming Chat Completions responses, emitting unified `ContentThinking` / `StreamEventReasoning*` types
- Round-trip `reasoning_content` in outgoing assistant messages for multi-turn reasoning preservation
- Extract native `reasoning_tokens` from `completion_tokens_details`; fall back to chars/4 estimation
- Add `ProviderQuirks` system with named presets (`kimi-k2.5`, `glm-5`) configurable via `OPENAI_COMPATIBLE_PROVIDER_QUIRKS` env var
- Quirk behaviors: locked hyperparameters, tool_choice restriction, stop sequence limits, empty content stripping, JSON schema downgrade, finish reason mapping

## Test plan
- 47/47 tests pass (24 pre-existing + 23 new)
- Integration tests exercise full Kimi K2.5 and GLM 5.0 conversation flows with httptest mocks
- `go vet ./llm/providers/openaicompat/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)