### PR TITLE
llm: require published serf/auth v0.1.0

### DIFF
--- a/llm/go.mod
+++ b/llm/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
-	primeradiant.com/serf/auth v0.0.0
+	primeradiant.com/serf/auth v0.1.0
 )

--- a/llm/go.sum
+++ b/llm/go.sum
@@ -5,3 +5,5 @@ github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNs
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
+primeradiant.com/serf/auth v0.1.0 h1:exdbfUlobcY4CdJS0Xs7cAqREbm5l5p1ssDgAFOaW38=
+primeradiant.com/serf/auth v0.1.0/go.mod h1:UPPCVkSd9dJuI+OmHoNzuymnmuUnTK/0iAInh31ZAio=


### PR DESCRIPTION
Bumps serf/auth from the v0.0.0 placeholder to the released auth/v0.1.0 tag so go get resolves serf/llm without a local replace. go.work still overrides locally. Part of PRI-2112 (publishing serf via vanity import).